### PR TITLE
Fixed compile error for C3

### DIFF
--- a/libraries/Kalman/KF_IO_PC.cpp
+++ b/libraries/Kalman/KF_IO_PC.cpp
@@ -10,7 +10,7 @@
 //      Compiled as a Windows console application.
 //  Other modules required:
 //		KalmanFilter.cpp; Matrix.h; Matrix.c
-
+/*
 #include "stdafx.h"   // required for MSVC. Remove for Arduino.
 #include "Matrix.h"
 void filter(matrix& x, matrix& P, matrix& meas);
@@ -127,3 +127,4 @@ void Show(float x)
 {
 	printf("%.6f, ", x);
 }
+*/


### PR DESCRIPTION
This comments out the file KF_IO_PC.cpp which seems to the the issue when compiling C3. I'm not ready to delete this file because I don't know how it works with other parts of the system.