### PR TITLE
[Vision] Build System Improvements

### DIFF
--- a/Elcano_C7_Vision/README.md
+++ b/Elcano_C7_Vision/README.md
@@ -50,7 +50,7 @@ Developer Overview
 Todo
 ----
 
-- Generate a classifier file for a cone
+- Generate a classifier file for a cone (`arduino.cc`)
 - The exact transformation between the input from localization and the output to the driver (`transform.cc`)
 - Parse input/write output in the correct format for `[project root]/libraries/Elcano_Serial`
 - Write test suite for `arduino.cc`

--- a/Elcano_C7_Vision/README.md
+++ b/Elcano_C7_Vision/README.md
@@ -16,8 +16,11 @@ Dependencies
 - [taywee/args](https://github.com/taywee/args) (argument parser)
 	- This is included in-tree in `args.hh`
 
-Note that raspicam lacks a pkgconf file, so we manually link inside
-meson.build. If this changes in the future, change it here.
+Note that raspicam lacks a pkgconf file, so we manually create the
+dependency in `meson.build`. Also, the serial dependency has a custom
+`meson.build` file because the original project uses a bizare system
+that I was having problems with. It may be a good idea to try and
+upstream the build file.
 
 Build Instructions
 ------------------
@@ -50,7 +53,7 @@ Developer Overview
 Todo
 ----
 
-- Generate a classifier file for a cone (`arduino.cc`)
+- Generate a classifier file for a cone (`detect.cc`)
 - The exact transformation between the input from localization and the output to the driver (`transform.cc`)
 - Parse input/write output in the correct format for `[project root]/libraries/Elcano_Serial`
-- Write test suite for `arduino.cc`
+- Write test suites for `arduino.cc` and `detect.cc`

--- a/Elcano_C7_Vision/detect.cc
+++ b/Elcano_C7_Vision/detect.cc
@@ -1,8 +1,3 @@
-#include <vector>
-#include <opencv2/highgui/highgui.hpp>
-#include <opencv2/imgproc/imgproc.hpp>
-#include "detect.hh"
-
 /* Helper function for processing camera input */
 
 using namespace cv;

--- a/Elcano_C7_Vision/detect.hh
+++ b/Elcano_C7_Vision/detect.hh
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <opencv2/objdetect/objdetect.hpp>
-
 /* Helper function for processing camera input */
 
 namespace elcano

--- a/Elcano_C7_Vision/main.cc
+++ b/Elcano_C7_Vision/main.cc
@@ -1,11 +1,6 @@
-#include <opencv2/opencv.hpp>
-#include <raspicam/raspicam_cv.h>
-#include "args.hh"
-#include "detect.hh"
-#include <iostream>
-#include <vector>
-#include <signal.h>
 #include <serial/serial.h>
+#include "detect.hh"
+#include "args.hh"
 
 using namespace cv;
 

--- a/Elcano_C7_Vision/meson.build
+++ b/Elcano_C7_Vision/meson.build
@@ -3,10 +3,12 @@ project('elcano-vision', 'cpp',
 	default_options: ['cpp_std=c++14']
 )
 
-add_global_link_arguments('-lraspicam', '-lraspicam_cv', language: 'cpp')
-
 subdir('serial-1.2.1')
 cv = dependency('opencv')
+rcam = declare_dependency(
+	link_args: ['-lraspicam', '-lraspicam_cv'],
+	dependencies: cv
+)
 
 executable('elcano-pi',
 	sources: [
@@ -15,7 +17,7 @@ executable('elcano-pi',
 		'arduino.cc',
 		'transform.cc'
 	],
-	dependencies: [cv, serial]
+	dependencies: [cv, serial, rcam]
 )
 
 transform_test = executable('transform-test',
@@ -39,7 +41,7 @@ detect_test = executable('detect-test',
 		'test-detect.cc',
 		'detect.cc'
 	],
-	dependencies: cv
+	dependencies: [cv, rcam]
 )
 
 test('transform test', transform_test)

--- a/Elcano_C7_Vision/meson.build
+++ b/Elcano_C7_Vision/meson.build
@@ -6,7 +6,6 @@ project('elcano-vision', 'cpp',
 add_global_link_arguments('-lraspicam', '-lraspicam_cv', language: 'cpp')
 
 subdir('serial-1.2.1')
-
 cv = dependency('opencv')
 
 executable('elcano-pi',
@@ -16,9 +15,7 @@ executable('elcano-pi',
 		'arduino.cc',
 		'transform.cc'
 	],
-	dependencies: cv,
-	link_with: serial_lib,
-	include_directories: serial_inc
+	dependencies: [cv, serial]
 )
 
 transform_test = executable('transform-test',
@@ -29,4 +26,22 @@ transform_test = executable('transform-test',
 	dependencies: cv
 )
 
+arduino_test = executable('arduino-test',
+	sources: [
+		'test-arduino.cc',
+		'arduino.cc'
+	],
+	dependencies: serial
+)
+
+detect_test = executable('detect-test',
+	sources: [
+		'test-detect.cc',
+		'detect.cc'
+	],
+	dependencies: cv
+)
+
 test('transform test', transform_test)
+test('arduino test', arduino_test)
+test('detect test', detect_test)

--- a/Elcano_C7_Vision/meson.build
+++ b/Elcano_C7_Vision/meson.build
@@ -17,7 +17,8 @@ executable('elcano-pi',
 		'arduino.cc',
 		'transform.cc'
 	],
-	dependencies: [cv, serial, rcam]
+	dependencies: [cv, serial, rcam],
+	cpp_pch: 'pch/elcano-pi-pch.hh'
 )
 
 transform_test = executable('transform-test',
@@ -25,7 +26,8 @@ transform_test = executable('transform-test',
 		'test-transform.cc',
 		'transform.cc'
 	],
-	dependencies: cv
+	dependencies: cv,
+	cpp_pch: 'pch/transform-test-pch.hh'
 )
 
 arduino_test = executable('arduino-test',
@@ -33,7 +35,8 @@ arduino_test = executable('arduino-test',
 		'test-arduino.cc',
 		'arduino.cc'
 	],
-	dependencies: serial
+	dependencies: serial,
+	cpp_pch: 'pch/arduino-test-pch.hh'
 )
 
 detect_test = executable('detect-test',
@@ -41,7 +44,8 @@ detect_test = executable('detect-test',
 		'test-detect.cc',
 		'detect.cc'
 	],
-	dependencies: [cv, rcam]
+	dependencies: [cv, rcam],
+	cpp_pch: 'pch/detect-test-pch.hh'
 )
 
 test('transform test', transform_test)

--- a/Elcano_C7_Vision/pch/arduino-test-pch.hh
+++ b/Elcano_C7_Vision/pch/arduino-test-pch.hh
@@ -1,0 +1,1 @@
+#include <iostream>

--- a/Elcano_C7_Vision/pch/detect-test-pch.hh
+++ b/Elcano_C7_Vision/pch/detect-test-pch.hh
@@ -1,0 +1,4 @@
+#include <vector>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/objdetect/objdetect.hpp>

--- a/Elcano_C7_Vision/pch/elcano-pi-pch.hh
+++ b/Elcano_C7_Vision/pch/elcano-pi-pch.hh
@@ -1,0 +1,7 @@
+#include <opencv2/opencv.hpp>
+#include <raspicam/raspicam_cv.h>
+#include <iostream>
+#include <vector>
+#include <tuple>
+#include <signal.h>
+#include <tgmath.h>

--- a/Elcano_C7_Vision/pch/transform-test-pch.hh
+++ b/Elcano_C7_Vision/pch/transform-test-pch.hh
@@ -1,0 +1,4 @@
+#include <iostream>
+#include <tgmath.h>
+#include <opencv2/core/core.hpp>
+#include <tuple>

--- a/Elcano_C7_Vision/serial-1.2.1/meson.build
+++ b/Elcano_C7_Vision/serial-1.2.1/meson.build
@@ -1,11 +1,19 @@
-
 serial_inc = include_directories('include')
 
 serial_lib = library('serial',
 	sources: [
 		'src/serial.cc',
 		'src/impl/unix.cc',
-		'src/impl/list_ports/list_ports_linux.cc'
+		'src/impl/win.cc',
+		'src/impl/list_ports/list_ports_linux.cc',
+		'src/impl/list_ports/list_ports_osx.cc',
+		'src/impl/list_ports/list_ports_win.cc'
 	],
 	include_directories: serial_inc
+)
+
+serial = declare_dependency(
+	link_with: serial_lib,
+	include_directories: serial_inc,
+	version: '1.2.1'
 )

--- a/Elcano_C7_Vision/test-arduino.cc
+++ b/Elcano_C7_Vision/test-arduino.cc
@@ -1,5 +1,3 @@
-#include "arduino.hh"
-
 /* Test suite for arduino.cc */
 
 int

--- a/Elcano_C7_Vision/test-arduino.cc
+++ b/Elcano_C7_Vision/test-arduino.cc
@@ -1,0 +1,11 @@
+#include "arduino.hh"
+
+/* Test suite for arduino.cc */
+
+int
+main(
+	int argc,
+	char **argv
+) {
+	/* TODO */
+}

--- a/Elcano_C7_Vision/test-detect.cc
+++ b/Elcano_C7_Vision/test-detect.cc
@@ -1,0 +1,11 @@
+#include "detect.hh"
+
+/* Test suite for detect.cc */
+
+int
+main(
+	int argc,
+	char **argv
+) {
+	/* TODO */
+}

--- a/Elcano_C7_Vision/test-detect.cc
+++ b/Elcano_C7_Vision/test-detect.cc
@@ -1,5 +1,3 @@
-#include "detect.hh"
-
 /* Test suite for detect.cc */
 
 int

--- a/Elcano_C7_Vision/test-transform.cc
+++ b/Elcano_C7_Vision/test-transform.cc
@@ -1,10 +1,9 @@
 #include "transform.hh"
-#include <iostream>
 
 /* Test suite for transform.cc
    Compare with [project path]/Vision/spacial_prototype.py */
 
-const double M_PI = 3.141592654;
+const double pi = 3.141592654;
 
 std::ostream&
 operator<<(
@@ -24,8 +23,8 @@ main(
 
 	std::cout << std::endl << "Testing 2D->3D Z-dist Generation:" << std::endl;
 	std::cout << "(h=height,f=field of view (y-axis))" << std::endl;
-	std::cout << "h=480,f=pi/2: " << elcano::get_z(480, M_PI / 2.0) << std::endl;
-	std::cout << "h=480,f=8pi/9: " << elcano::get_z(480, 8.0 * M_PI / 9.0) << std::endl;
+	std::cout << "h=480,f=pi/2: " << elcano::get_z(480, pi / 2.0) << std::endl;
+	std::cout << "h=480,f=8pi/9: " << elcano::get_z(480, 8.0 * pi / 9.0) << std::endl;
 	
 	std::cout << std::endl << "Testing Global->Relative Transformation" << std::endl;
 	std::cout << "(a=camera angle, c=camera position, p=cone position, i=image size," << std::endl;

--- a/Elcano_C7_Vision/transform.cc
+++ b/Elcano_C7_Vision/transform.cc
@@ -1,7 +1,3 @@
-#include "transform.hh"
-#include <tgmath.h>
-#include <opencv2/core/core.hpp>
-
 /* Transform on-camera rectangles into vectors in 3D space */
 
 namespace elcano

--- a/Elcano_C7_Vision/transform.hh
+++ b/Elcano_C7_Vision/transform.hh
@@ -1,8 +1,5 @@
 #pragma once
 
-#include "types.hh"
-#include <tuple>
-
 /* Transform on-camera rectangles into vectors in 3D space */
 
 namespace elcano


### PR DESCRIPTION
With these improvements, I've made some improvements I've been meaning to make for a while:

* The build system previously used some global linker arguments, which are generally considered a bad practice. This has been fixed.
* The `meson.build` file for the serial library has been significantly improved.
* Skeletons have been added in the build system for unit tests for `arduino.cc` and `detect.cc`
* We now use precompiled headers, which should dramatically improve build times going forward.