### PR TITLE
Rewrite Elcano_Serial for Arduinos

### DIFF
--- a/libraries/Elcano_Serial/Elcano_Serial.cpp
+++ b/libraries/Elcano_Serial/Elcano_Serial.cpp
@@ -1,87 +1,127 @@
-﻿/*
-Elcano_Serial.cpp
-Tyler Folsom   Sept 7, 2015 Modified 9/2/16 JJB
-
-The routines writeSerial and readSerial transfer the information in a SerialData
-structure over serial lines connecting Arduino microcontrollers. The contents of the messages are specified in SerialCmd.html. Note that messages are limited to 64 characters.
-
-Data transfer has been verified by the program SerialUnitTest.ino.
-When running a program from your sketchbook, create the subdirectory
-libraries/Elcano_Serial, and place both Elcano_Serial.cpp and Elcano_Serial.h there.
-
-*/
-#include "string.h"
-#include "math.h"
 #include "Elcano_Serial.h"
 
-
-/*------------------------------------------------------------------------------*/ 
-/* GetWord
-** Reads to see if message contains a whole word
-*/
-char * GetWord(char * major, char * str){
-    char * CSp1;
-
-    CSp1 = strstr( str, major);
-    if (CSp1!=NULL)
-    CSp1 += strlen(major);
-
-    return CSp1;
+// Detects if a character (c) is within a string (s) with size (n)
+static bool contains(char *s, size_t n, char c) {
+	for (char *i = s; i < s + n; ++i) if (*i == c) return 1;
+	return 0;
 }
-/*-------------------------------------------------------------------------------*/
-/* GetNumber
-** Checks string to see if message contains a completed number
-*/
-float GetNumber(char *minor, char*Args)
-{
-  float data = NaN;
-  if (Args == NULL) return data;
-  // minor is a keyword; grab the associated value.
-  char * Number = GetWord(minor, Args);
-  if (Number==NULL) return data;
-   // change } to 0
-   char* end = strchr(Number, '}');
-   if (end == NULL) return NaN;
-   *end = '\0';
-   data = atof(Number);
-   // change back to }
-   *end = '}';
-   return data;
+
+// Proceses input from a device (dev) and yields the next token
+// May set an auxillary value (aux) if applicable
+static int yylex(HardwareSerial *dev, long *aux) {
+	char c, flip = 0;
+start:
+	while (contains(" \t\r\0", 4, c = dev->read()));
+	if (c == '\n') return 0;
+	if (c == '-' || (c >= '0' && c <= '9')) {
+		*aux = 0;
+		for (;;) {
+			*aux *= 10;
+			if (c == '-') flip = 1; else *aux += c - '0';
+			c = dev->peek();
+			if (c < '0' || c > '9') break;
+			c = dev->read();
+		}
+		if (flip) *aux = -*aux;
+		return '#';
+	}
+	if (contains("DSGXnsabpr,{}", 13, c)) return c;
+	goto start;
 }
-/*---------------------------------------------------------------------------------------*/
-/* GetPos
-** Pulls position data from buffer
-*/
-void GetPos(char *minor, char*Args, SerialData *SerialD)
-{
-  SerialD->posE_cm = SerialD->posN_cm = NaN;
-  if (Args == NULL) return;
-  // minor is a keyword; grab the associated value.
-  char * Number = GetWord(minor, Args);
-  if (Number==NULL) return;
-   // change , to 0
-   char* end = strchr(Number, ',');
-   if (end == NULL) return;
-   *end = '\0';
-   SerialD->posE_cm = (long) atof(Number);
-   // change back to ,
-   *end = ',';
-   Number = end+1;  // 2nd number
-   // change } to 0
-   SerialD->posN_cm = (long) atof(Number);
-   end = strchr(Number, '}');
-   if (end == NULL) return;
-   *end = '\0';
-   SerialD->posN_cm = atof(Number);
-   // change back to ,
-   *end = ',';
+
+// Parses input from a device (dev) and writes out serial data (dt)
+// Returns 0 if successful, -1 otherwise
+int readSerial(HardwareSerial *dev, SerialData *dt) {
+	long aux;
+	dt->Clear();
+	if (dev->available() <= 0) return 1;
+	
+#define LEX yylex(dev, &aux)
+	int l = LEX;
+	switch (l) {
+	case 'D': dt->kind = MSG_DRIVE;  break;
+	case 'S': dt->kind = MSG_SENSOR; break;
+	case 'G': dt->kind = MSG_GOAL;   break;
+	case 'X': dt->kind = MSG_SEG;    break;
+	default:  dt->kind = MSG_NONE;
+	}
+arg:
+	l = LEX;
+	if (l == '{') {
+		int c = LEX;
+		int d = LEX;
+		
+		if (d != '#') return 4;
+		switch (c) {
+		case 'n': dt->number      = aux; break;
+		case 's': dt->speed_cmPs  = aux; break;
+		case 'a': dt->angle_deg   = aux; break;
+		case 'b': dt->bearing_deg = aux; break;
+		case 'r': dt->probability = aux; break;
+		case 'p':
+			dt->posE_cm = aux;
+			if (LEX != ',') return 4;
+			if (LEX != '#') return 5;
+			dt->posN_cm = aux;
+			break;
+		default:  return 3;
+		}
+		
+		if (LEX != '}') return 6;
+		goto arg;
+	} else if (l == '\n') return 0;
+#undef LEX
+	return 2;
 }
-/*-------------------------------------------------------------------------------*/
-/* Clear
-** Sets all SerialData members to non-values
-*/
-void SerialData::Clear()
-{
+
+// Writes a serial data structure (dt) to a device (dev)
+// Returns 0 if successful, -1 otherwise
+int writeSerial(HardwareSerial *dev, SerialData *dt) {
+	switch (dt->kind) {
+	case MSG_DRIVE:  dev->print("D"); break;
+	case MSG_SENSOR: dev->print("S"); break;
+	case MSG_GOAL:   dev->print("G"); break;
+	case MSG_SEG:    dev->print("X"); break;
+	default: return -1;
+	}
+	if (dt->number != NaN && (dt->kind == MSG_GOAL || dt->kind == MSG_SEG)) {
+		dev->print("{n ");
+		dev->print(dt->number);
+		dev->print("}");
+	}
+	if (dt->speed_cmPs != NaN && dt->kind != MSG_GOAL) {
+		dev->print("{s ");
+		dev->print(dt->speed_cmPs);
+		dev->print("}");
+	}
+	if (dt->angle_deg != NaN && (dt->kind == MSG_DRIVE || dt->kind == MSG_SENSOR)) {
+		dev->print("{a ");
+		dev->print(dt->angle_deg);
+		dev->print("}");
+	}
+	if (dt->bearing_deg != NaN && dt->kind != MSG_DRIVE) {
+		dev->print("{b ");
+		dev->print(dt->bearing_deg);
+		dev->print("}");
+	}
+	if (dt->posE_cm != NaN && dt->posN_cm != NaN && dt->kind != MSG_DRIVE) {
+		dev->print("{p ");
+		dev->print(dt->posE_cm);
+		dev->print(",");
+		dev->print(dt->posN_cm);
+		dev->print("}");
+	}
+	if (dt->probability != NaN && dt->kind == MSG_GOAL) {
+		dev->print("{r ");
+		dev->print(dt->probability);
+		dev->print("}");
+	}
+	dev->println("\0");
+	return 0;
+}
+
+// Sets the value of a SerialData struct to the defaults
+void SerialData::Clear() {
     kind = MSG_NONE;
     number = NaN;
     speed_cmPs = NaN;
@@ -90,293 +130,4 @@ void SerialData::Clear()
     posE_cm = NaN;
     posN_cm = NaN;
     probability = NaN;
-}
-/*-------------------------------------------------------------------------------*/
-/* Dump
-** Prints all SerialData values to Serial
-*/
-void Dump (char *IncomingMessage, SerialData *SerialD)
-{
-    Serial.println();
-    Serial.println(IncomingMessage);
-    Serial.print ( "Kind ");  Serial.print(SerialD->kind);
-    Serial.print ( "; Num ");  Serial.print(SerialD->number);
-    Serial.print ( "; Spd ");  Serial.print(SerialD->speed_cmPs);
-    Serial.print ( "; Ang ");  Serial.print(SerialD->angle_deg );
-    Serial.print ( "; Br ");  Serial.print(SerialD->bearing_deg );
-    Serial.print ( "; pos (");  Serial.print(SerialD->posE_cm);
-    Serial.print ( ", ");  Serial.print(SerialD->posN_cm);
-    Serial.print ( ") Prob ");  Serial.println(SerialD->probability);
-}
-
-/*-------------------------------------------------------------------------------*/
-/* ProcessMessage
-** Parses buffer for meaningful SerialData object members
-** Kinds:
-** S = SENSOR
-** D = DRIVE
-** G = GOAL
-** X = SEG
-** Data Members:
-** a = Ang 
-** b = Br
-** s = Speed
-** p = Pos
-** n = Num
-** r = Prob
-*/
-void ProcessMessage (char *IncomingMessage, SerialData *SerialD)
-{
-    float data;
-
- // Dump (IncomingMessage, SerialD) ;   // debug
-    // Determine if message is "SENSOR {Speed xxx.xx}"	
-    char * Args = GetWord ("S", IncomingMessage);//S for sensor
-    if (Args != NULL)
-    {	
-      data = GetNumber("s", Args);
-	if (data != NaN) 
-        {
-            SerialD->speed_cmPs = (long)(data);
-            SerialD->kind = MSG_SENSOR;
-        }
-      data = GetNumber("a", Args);
-	if (data != NaN) 
-        {
-            SerialD->angle_deg = (long)(data);
-            SerialD->kind = MSG_SENSOR;
-        }
-      data = GetNumber("b", Args);
-	if (data != NaN) 
-        {
-            SerialD->bearing_deg = (long)(data);
-            SerialD->kind = MSG_SENSOR;
-        }
-      GetPos("p", Args, SerialD);
-      if (SerialD->posN_cm != NaN && SerialD->posE_cm != NaN)
-            SerialD->kind = MSG_SENSOR;
-   }
-    // Determine if message is "DRIVE {Speed xxx.xx}"	
-    Args = GetWord ("D", IncomingMessage);
-    if (Args != NULL)
-    {	
-        data = GetNumber("s", Args);
-	  if (data != NaN) 
-        {
-            SerialD->speed_cmPs = (long)(data);
-            SerialD->kind = MSG_DRIVE;
-        }
-        data = GetNumber("a", Args);
-	if (data != NaN) 
-        {
-            SerialD->angle_deg = (long)(data);
-            SerialD->kind = MSG_DRIVE;
-        }
-    }
-    Args = GetWord ("G", IncomingMessage);
-    if (Args != NULL)
-    {	
-      data = GetNumber("n", Args);
-	if (data != NaN) 
-        {
-            SerialD->number = (long)(data);
-        }
-      GetPos("p", Args, SerialD);
-      data = GetNumber("b", Args);
-	if (data != NaN) 
-        {
-            SerialD->bearing_deg = (long)(data);
-        }
-       data = GetNumber("r", Args);
-	if (data != NaN) 
-        {  // from vision: probability that cone is present in the image
-            SerialD->probability = (long)(data);
-        }
-        if (SerialD->posN_cm != NaN && SerialD->posE_cm != NaN) // && SerialD->number > 0)
-            SerialD->kind = MSG_GOAL;
-   }
-    Args = GetWord ("X", IncomingMessage); //X for segment
-    if (Args != NULL)
-    {	
-        data = GetNumber("n", Args);
-	if (data != NaN) 
-        {
-            SerialD->number = (long)(data);
-        }
-        data = GetNumber("s", Args);
-	if (data != NaN) 
-        {
-            SerialD->speed_cmPs = (long)(data);
-        }
-        data = GetNumber("b", Args);
-	if (data != NaN) 
-        {
-            SerialD->bearing_deg = (long)(data);
-        }
-      GetPos("p", Args, SerialD);
-        if (SerialD->posN_cm != NaN && SerialD->posE_cm != NaN && SerialD->number != NaN)
-            SerialD->kind = MSG_SEG;
-   }
-
-}
-/*------------------------------------------------------------------------------*/ 
-// If there is an issue with missing data the kind might not be correctly set
-// for sending that data.
-
-
-bool readSerial(HardwareSerial *SerialN, SerialData *SerialD)
-{
-    //SerialD->Clear();
-    static char IncomingMessage[BUFFER_SIZE];
-    static int InIndex = 0;  // Input side, current character of SerialDrive message
-    int incomingByte = 0;   // for incoming serial data
-    while (SerialN->available())
-    {
-		SerialN->readBytesUntil('\0', IncomingMessage, BUFFER_SIZE);
-		return true;
-        // read the incoming byte from C4:
-        // incomingByte = SerialN->read();
-        // IncomingMessage[InIndex] = (char)(incomingByte);
-        // IncomingMessage[InIndex+1] = 0;
-        // if (IncomingMessage[InIndex] == 0 || incomingByte == '\n' || incomingByte == '\r'
-         // || InIndex >= BUFFER_SIZE-1)
-        // {
-            // ProcessMessage(&IncomingMessage[0], SerialD);  // see what we got
-            // for (InIndex = 0; InIndex < BUFFER_SIZE; InIndex++)
-                // IncomingMessage[InIndex] = 0;
-            // InIndex = 0;
-            // IncomingMessage[InIndex] = 0;
-
-        // }
-       // else
-       // {
-       //  incomingByte > 31? Serial.print(IncomingMessage[InIndex]): Serial.print(incomingByte);
-           // ++InIndex;        
-       // }        
-    }
-	return false;
-}
-/*-------------------------------------------------------------------------------*/ 
-void writeSerial(HardwareSerial *SerialN, struct SerialData *SerialD )
-{
-// Caution: 64 character limit for Arduino serial. Buffer size is set in the Arduino core.
-// If the message produced is > 64 characters, readSerial will ignore it.
-// writeSerial will only send data that relates to the kind. ex In the Serial data struct 
-//if kind is 0 the only data sent will be kind angle and direction.
-    switch (SerialD->kind) 
-    {
-    case MSG_DRIVE:
-        SerialN->print("D");
-        if (SerialD->speed_cmPs != NaN)
-        {
-            SerialN->print(" {s ");
-            SerialN->print(SerialD->speed_cmPs);
-            SerialN->print("}");
-        }
-        if (SerialD->angle_deg != NaN)
-        {
-            SerialN->print(" {a ");
-            SerialN->print(SerialD->angle_deg);
-            SerialN->print("}");
-        }
-        SerialN->println("\0");
-        break;
-        
-    case MSG_SENSOR:
-        SerialN->print("S");
-        if (SerialD->speed_cmPs != NaN)
-        {
-            SerialN->print(" {s ");
-            SerialN->print(SerialD->speed_cmPs);
-            SerialN->print("}");
-        }
-        if (SerialD->angle_deg != NaN)
-        {
-            SerialN->print(" {a ");
-            SerialN->print(SerialD->angle_deg);
-            SerialN->print("}");
-        }
-        if (SerialD->posE_cm != NaN && SerialD->posN_cm != NaN)
-        {
-            SerialN->print(" {p ");
-            SerialN->print(SerialD->posE_cm);
-            SerialN->print(",");
-            SerialN->print(SerialD->posN_cm);
-            SerialN->print("}");
-        }
-       if (SerialD->bearing_deg != NaN)
-        {
-            SerialN->print(" {b ");
-            SerialN->print(SerialD->bearing_deg);
-            SerialN->print("}");
-        }
-        SerialN->println("\0");
-        break;
-        
-    case MSG_GOAL:
-        SerialN->print("G");
-        if (SerialD->number != NaN)
-        {
-            SerialN->print(" {n ");
-            SerialN->print(SerialD->number);
-            SerialN->print("}");
-        }
-        if (SerialD->posE_cm != NaN && SerialD->posN_cm != NaN)
-        {
-            SerialN->print(" {p ");
-            SerialN->print(SerialD->posE_cm);
-            SerialN->print(",");
-            SerialN->print(SerialD->posN_cm);
-            SerialN->print("}");
-        }
-        if (SerialD->bearing_deg != NaN)
-        {
-            SerialN->print(" {b ");
-            SerialN->print(SerialD->bearing_deg);
-            SerialN->print("}");
-        }
-         if (SerialD->probability != NaN)
-        {
-            SerialN->print(" {r ");
-            SerialN->print(SerialD->probability);
-            SerialN->print("}");
-        }
-       SerialN->println("\0");
-        break;
-
-    case MSG_SEG:
-        SerialN->print("X");
-        if (SerialD->number != NaN)
-        {
-            SerialN->print(" {n ");
-            SerialN->print(SerialD->number);
-            SerialN->print("}");
-        }
-        if (SerialD->posE_cm != NaN && SerialD->posN_cm != NaN)
-        {
-            SerialN->print(" {p ");
-            SerialN->print(SerialD->posE_cm);
-            SerialN->print(",");
-            SerialN->print(SerialD->posN_cm);
-            SerialN->print("}");
-        }
-       if (SerialD->bearing_deg != NaN)
-        {
-            SerialN->print(" {b ");
-            SerialN->print(SerialD->bearing_deg);
-            SerialN->print("}");
-        }
-        if (SerialD->speed_cmPs != NaN)
-        {
-            SerialN->print(" {s ");
-            SerialN->print(SerialD->speed_cmPs);
-            SerialN->print("}");
-        }
-        SerialN->println("\0");
-        break;
-
-    case MSG_NONE:
-    default:
-        break;
-    }
 }

--- a/libraries/Elcano_Serial/Elcano_Serial.h
+++ b/libraries/Elcano_Serial/Elcano_Serial.h
@@ -33,7 +33,6 @@ Segment - 4 (C4 to C3)
    - posN_cm
    - bearing_deg
    - speed_cmPs
-
 */
 
 struct SerialData
@@ -50,8 +49,5 @@ struct SerialData
     void Clear();
 };
 
-char * GetWord(char * major, char * str);
-float GetNumber(char *minor, char*Args);
-void ProcessMessage (char *IncomingMessage, SerialData *SerialD);
-void readSerial(HardwareSerial *SerialN, struct SerialData *SerialD );
-void writeSerial(HardwareSerial *SerialN, struct SerialData *SerialD );
+int readSerial(HardwareSerial *SerialN, struct SerialData *SerialD );
+int writeSerial(HardwareSerial *SerialN, struct SerialData *SerialD );


### PR DESCRIPTION
This rewrites the Elcano_Serial library more in the style of a
lexer/parser, as it is now completely bufferless (outside of the API)
and more stable than the previous version, according to Chase. While not
perfect (that would require a state machine, which is still being mapped
out), this will be neccessary for the presentation next week.