### PR TITLE
[WIP] Remove the null space from the ES format

### DIFF
--- a/Elcano_C7_Vision/arduino.cc
+++ b/Elcano_C7_Vision/arduino.cc
@@ -144,7 +144,7 @@ namespace elcano
 	) {
 		std::ostringstream ss;
 		write(ss, info);
-		ss << "\0\n";
+		ss << "\n";
 		device.write(ss.str());
 	}
 }

--- a/libraries/Elcano_Serial/Elcano_Serial.cpp
+++ b/libraries/Elcano_Serial/Elcano_Serial.cpp
@@ -11,7 +11,7 @@ static bool contains(char *s, size_t n, char c) {
 static int yylex(HardwareSerial *dev, long *aux) {
 	char c, flip = 0;
 start:
-	while (contains(" \t\r\0", 4, c = dev->read()));
+	c = dev->read();
 	if (c == '\n') return 0;
 	if (c == '-' || (c >= '0' && c <= '9')) {
 		*aux = 0;
@@ -43,7 +43,7 @@ int readSerial(HardwareSerial *dev, SerialData *dt) {
 	case 'S': dt->kind = MSG_SENSOR; break;
 	case 'G': dt->kind = MSG_GOAL;   break;
 	case 'X': dt->kind = MSG_SEG;    break;
-	default:  dt->kind = MSG_NONE;
+	default : return 1;
 	}
 arg:
 	l = LEX;
@@ -116,7 +116,7 @@ int writeSerial(HardwareSerial *dev, SerialData *dt) {
 		dev->print(dt->probability);
 		dev->print("}");
 	}
-	dev->println("\0");
+	dev->print("\n");
 	return 0;
 }
 


### PR DESCRIPTION
This primarily removes the usage of a "\0" character before new lines in
the Elcano_Serial format. This also prevents a potential infinite loop
in the yylex function, and provides an actual error message when there
is an inaccurate message type, instead of a silent continue.

I am leaving this pull request as WIP, as we track down any more possible bugs with this code, especially because the changes are currently so tiny. DON'T MERGE IT YET!