### PR TITLE
Use namespace/enums in Elcano_Serial

### DIFF
--- a/libraries/Elcano_Serial/Elcano_Serial.cpp
+++ b/libraries/Elcano_Serial/Elcano_Serial.cpp
@@ -7,10 +7,12 @@
 ** Manages our protocal for robust communication of SerialData over serial connections
 */
 
-int8_t ParseState::update(void) {
+namespace elcano {
+
+ParseStateError ParseState::update(void) {
 	int c = dev->read();
-	if (c == -1) return PSE_UNAVAILABLE;
-	if (c == ' ' || c == '\t' || c == '\0' || c == '\r') return PSE_INCOMPLETE;
+	if (c == -1) return ParseStateError::unavailable;
+	if (c == ' ' || c == '\t' || c == '\0' || c == '\r') return ParseStateError::incomplete;
 	switch(state) {
 	case 0:
 		// During this state, we begin the processing of a new SerialData
@@ -18,60 +20,60 @@ int8_t ParseState::update(void) {
 		// we are working with
 		dt->clear();
 		switch(c) {
-		case 'D': dt->kind = MSG_DRIVE;  break;
-		case 'S': dt->kind = MSG_SENSOR; break;
-		case 'G': dt->kind = MSG_GOAL;   break;
-		case 'X': dt->kind = MSG_SEG;    break;
-		default : return PSE_BAD_TYPE;
+		case 'D': dt->kind = MsgType::drive;  break;
+		case 'S': dt->kind = MsgType::sensor; break;
+		case 'G': dt->kind = MsgType::goal;   break;
+		case 'X': dt->kind = MsgType::seg;    break;
+		default : return ParseStateError::bad_type;
 		}
 		state = 1;
-		return PSE_INCOMPLETE;
+		return ParseStateError::incomplete;
 	case 1:
 		// During this state, we need to find '{' if we are reading the value
 		// for an attribute, or '\n' if we are done with the packet
 		switch(c) {
-		case '\n': state = 0; return dt->verify() ? PSE_SUCCESS : PSE_INVAL_COMB;
-		case '{' : state = 2; return PSE_INCOMPLETE;
-		default  : return PSE_BAD_LCURLY;
+		case '\n': state = 0; return dt->verify() ? ParseStateError::success : ParseStateError::inval_comb;
+		case '{' : state = 2; return ParseStateError::incomplete;
+		default  : return ParseStateError::bad_lcurly;
 		}
 	case 2:
 		// During this state, we begin reading an attribute of the SerialData
 		// and we must recieve {n,s,a,b,r,p} to state _which_ attribute
 		switch(c) {
-		case 'n': state = 3; dt->number      = 0; return PSE_INCOMPLETE;
-		case 's': state = 4; dt->speed_cmPs  = 0; return PSE_INCOMPLETE;
-		case 'a': state = 5; dt->angle_deg   = 0; return PSE_INCOMPLETE;
-		case 'b': state = 6; dt->bearing_deg = 0; return PSE_INCOMPLETE;
-		case 'r': state = 7; dt->probability = 0; return PSE_INCOMPLETE;
-		case 'p': state = 8; dt->posE_cm = 0; dt->posN_cm = 0; return PSE_INCOMPLETE;
-		default : return PSE_BAD_ATTRIB;
+		case 'n': state = 3; dt->number      = 0; return ParseStateError::incomplete;
+		case 's': state = 4; dt->speed_cmPs  = 0; return ParseStateError::incomplete;
+		case 'a': state = 5; dt->angle_deg   = 0; return ParseStateError::incomplete;
+		case 'b': state = 6; dt->bearing_deg = 0; return ParseStateError::incomplete;
+		case 'r': state = 7; dt->probability = 0; return ParseStateError::incomplete;
+		case 'p': state = 8; dt->posE_cm = 0; dt->posN_cm = 0; return ParseStateError::incomplete;
+		default : return ParseStateError::bad_attrib;
 		}
-#define STATES(SS, PS, NS, TERM, HOME, VAR) \
-    case SS:                                \
-        if (c == '-')              {        \
-            state = NS;                     \
-            return PSE_INCOMPLETE; }        \
-        state = PS;                         \
-    case PS:                                \
-        if (c >= '0' && c <= '9')  {        \
-            dt->VAR *= 10;                  \
-            dt->VAR += c - '0';             \
-            return PSE_INCOMPLETE; }        \
-        else if (c == TERM)        {        \
-            state = HOME;                   \
-            return PSE_INCOMPLETE; }        \
-        else                                \
-            return PSE_BAD_NUMBER;          \
-    case NS:                                \
-        if (c >= '0' && c <= '9')  {        \
-            dt->VAR *= 10;                  \
-            dt->VAR -= c - '0';             \
-            return PSE_INCOMPLETE; }        \
-        else if (c == TERM)        {        \
-            state = HOME;                   \
-            return PSE_INCOMPLETE; }        \
-        else                                \
-            return PSE_BAD_NUMBER;
+#define STATES(SS, PS, NS, TERM, HOME, VAR)   \
+    case SS:                                   \
+        if (c == '-') {                         \
+            state = NS;                          \
+            return ParseStateError::incomplete; } \
+        state = PS;                               \
+    case PS:                                      \
+        if (c >= '0' && c <= '9') {               \
+            dt->VAR *= 10;                        \
+            dt->VAR += c - '0';                   \
+            return ParseStateError::incomplete; } \
+        else if (c == TERM) {                     \
+            state = HOME;                         \
+            return ParseStateError::incomplete; } \
+        else                                      \
+            return ParseStateError::bad_number;   \
+    case NS:                                      \
+        if (c >= '0' && c <= '9') {               \
+            dt->VAR *= 10;                        \
+            dt->VAR -= c - '0';                   \
+            return ParseStateError::incomplete; } \
+        else if (c == TERM) {                     \
+            state = HOME;                         \
+            return ParseStateError::incomplete; } \
+        else                                      \
+            return ParseStateError::bad_number;
 STATES(3, 13, 23, '}', 1, number)
 STATES(4, 14, 24, '}', 1, speed_cmPs)
 STATES(5, 15, 25, '}', 1, angle_deg)
@@ -85,40 +87,40 @@ STATES(9, 19, 29, '}', 1, posN_cm)
 
 bool SerialData::write(HardwareSerial *dev) {
 	switch (kind) {
-	case MSG_DRIVE:  dev->print("D"); break;
-	case MSG_SENSOR: dev->print("S"); break;
-	case MSG_GOAL:   dev->print("G"); break;
-	case MSG_SEG:    dev->print("X"); break;
+	case MsgType::drive:  dev->print("D"); break;
+	case MsgType::sensor: dev->print("S"); break;
+	case MsgType::goal:   dev->print("G"); break;
+	case MsgType::seg:    dev->print("X"); break;
 	default:         return false;
 	}
-	if (number != NaN && (kind == MSG_GOAL || kind == MSG_SEG)) {
+	if (number != NaN && (kind == MsgType::goal || kind == MsgType::seg)) {
 		dev->print("{n ");
 		dev->print(number);
 		dev->print("}");
 	}
-	if (speed_cmPs != NaN && kind != MSG_GOAL) {
+	if (speed_cmPs != NaN && kind != MsgType::goal) {
 		dev->print("{s ");
 		dev->print(speed_cmPs);
 		dev->print("}");
 	}
-	if (angle_deg != NaN && (kind == MSG_DRIVE || kind == MSG_SENSOR)) {
+	if (angle_deg != NaN && (kind == MsgType::drive || kind == MsgType::sensor)) {
 		dev->print("{a ");
 		dev->print(angle_deg);
 		dev->print("}");
 	}
-	if (bearing_deg != NaN && kind != MSG_DRIVE) {
+	if (bearing_deg != NaN && kind != MsgType::drive) {
 		dev->print("{b ");
 		dev->print(bearing_deg);
 		dev->print("}");
 	}
-	if (posE_cm != NaN && posN_cm != NaN && kind != MSG_DRIVE) {
+	if (posE_cm != NaN && posN_cm != NaN && kind != MsgType::drive) {
 		dev->print("{p ");
 		dev->print(posE_cm);
 		dev->print(",");
 		dev->print(posN_cm);
 		dev->print("}");
 	}
-	if (probability != NaN && kind == MSG_GOAL) {
+	if (probability != NaN && kind == MsgType::goal) {
 		dev->print("{r ");
 		dev->print(probability);
 		dev->print("}");
@@ -128,44 +130,46 @@ bool SerialData::write(HardwareSerial *dev) {
 }
 
 void SerialData::clear(void) {
-    kind = MSG_NONE;
-    number = NaN;
-    speed_cmPs = NaN;
-    angle_deg = NaN;
+    kind        = MsgType::none;
+    number      = NaN;
+    speed_cmPs  = NaN;
+    angle_deg   = NaN;
     bearing_deg = NaN;
-    posE_cm = NaN;
-    posN_cm = NaN;
+    posE_cm     = NaN;
+    posN_cm     = NaN;
     probability = NaN;
 }
 
 bool SerialData::verify(void) {
 	switch (kind) {
-	case MSG_DRIVE:
-		if (speed_cmPs == NaN) return false;
-		if (angle_deg  == NaN) return false;
+	case MsgType::drive:
+		if (speed_cmPs  == NaN) return false;
+		if (angle_deg   == NaN) return false;
 		break;
-	case MSG_SENSOR:
-		if (speed_cmPs == NaN)  return false;
-		if (posE_cm == NaN)     return false;
-		if (posN_cm == NaN)     return false;
+	case MsgType::sensor:
+		if (speed_cmPs  == NaN) return false;
+		if (posE_cm     == NaN) return false;
+		if (posN_cm     == NaN) return false;
 		if (bearing_deg == NaN) return false;
-		if (angle_deg == NaN)   return false;
+		if (angle_deg   == NaN) return false;
 		break;
-	case MSG_GOAL:
-		if (number == NaN)      return false;
-		if (posE_cm == NaN)     return false;
-		if (posN_cm == NaN)     return false;
+	case MsgType::goal:
+		if (number      == NaN) return false;
+		if (posE_cm     == NaN) return false;
+		if (posN_cm     == NaN) return false;
 		if (bearing_deg == NaN) return false;
 		break;
-	case MSG_SEG:
-		if (number == NaN)      return false;
-		if (posE_cm == NaN)     return false;
-		if (posN_cm == NaN)     return false;
+	case MsgType::seg:
+		if (number      == NaN) return false;
+		if (posE_cm     == NaN) return false;
+		if (posN_cm     == NaN) return false;
 		if (bearing_deg == NaN) return false;
-		if (speed_cmPs == NaN)  return false;
+		if (speed_cmPs  == NaN) return false;
 		break;
 	default:
 		return false;
 	}
 	return true;
 }
+
+} // namespace elcano

--- a/libraries/Elcano_Serial/Elcano_Serial.h
+++ b/libraries/Elcano_Serial/Elcano_Serial.h
@@ -9,32 +9,53 @@
 
 #include <HardwareSerial.h>
 
-#define NaN 0x7FFFFFFF
+namespace elcano {
 
-#define MSG_NONE   0
-#define MSG_DRIVE  1
-#define MSG_SENSOR 2
-#define MSG_GOAL   3
-#define MSG_SEG    4
+//! The number representing when no data is sent
+const int32_t NaN = 0x7FFFFFFF;
 
-#define PSE_INVAL_COMB   2
-#define PSE_SUCCESS      1
-#define PSE_INCOMPLETE   0
-#define PSE_UNAVAILABLE -1
-#define PSE_BAD_TYPE    -2
-#define PSE_BAD_LCURLY  -3
-#define PSE_BAD_ATTRIB  -4
-#define PSE_BAD_NUMBER  -5
+//! The different possible types of SerialData packets
+enum class MsgType : int8_t {
+	none   = 0, //!< Empty type
+	drive  = 1, //!< Drive to a position
+	/* speed_cmPs
+	** angle_deg
+	*/
+
+	sensor = 2, //!< Info from the sensor
+	/* speed_cmPs
+	** angle_deg
+	** posE_cm
+	** posN_cm
+	** bearing_deg
+	*/
+
+	goal   = 3, //!< Position of a goal
+	/* number
+	** posE_cm
+	** posN_cm
+	** bearing_deg
+	** probability (optional)
+	*/
+
+	seg    = 4  //!< Part of the navigation path
+	/* number
+	** posE_cm
+	** posN_cm
+	** bearing_deg
+	** speed_cmPs
+	*/
+};
 
 //! Contains information to send/recieve over a serial connection.
 struct SerialData {
-	uint8_t kind; //!< The type of message being received [0-4]
-	int32_t number; //!< The cone number
-	int32_t speed_cmPs; //!< The speed the bike is moving at (cm/s)
-	int32_t angle_deg; //!< Angle (deg) of the bike
+	MsgType kind;   //!< The type of message being received [0-4]
+	int32_t number; //!< The number of the unit
+	int32_t speed_cmPs;  //!< The speed the bike is moving at (cm/s)
+	int32_t angle_deg;   //!< Angle (deg) of the bike
 	int32_t bearing_deg; //!< Bearing (deg) of the camera
-	int32_t posE_cm; //!< Position (cm) on the E-W axis
-	int32_t posN_cm; //!< Position (cm) on the N-S axis
+	int32_t posE_cm;     //!< Position (cm) on the E-W axis
+	int32_t posN_cm;     //!< Position (cm) on the N-S axis
 	int32_t probability; //!< Probability that the value is a cone
 	
 	void clear(void); //!< Set the values to the defaults
@@ -42,21 +63,63 @@ struct SerialData {
 	bool verify(void); //!< Check that the types match the values
 };
 
+//! The different possible results of the ParseState::update method
+enum class ParseStateError : int8_t {
+	inval_comb  =  2, //!< Complete package, failed validation
+	success     =  1, //!< Complete package
+	incomplete  =  0, //!< Successful character read, not ready for usage
+	unavailable = -1, //!< Couldn't read a character from the device at this time
+	bad_type    = -2, //!< Syntax error: types should be [DSGX]
+	bad_lcurly  = -3, //!< Syntax error: expected '{' or '\n' but got neither
+	bad_attrib  = -4, //!< Syntax error: attributes should be [nsabpr]
+	bad_number  = -5  //!< Syntax error: number had a bad symbol
+};
+
 //! Contains internal state for the SerialData parser.
 struct ParseState {
 	HardwareSerial *dev; //!< Connection to read from
 	SerialData *dt; //!< SerialData to write to
 	
-	int8_t update(void); //!< Update the state of the parser based on a single character
+	ParseStateError update(void); //!< Update the state of the parser based on a single character
 private:
 	uint8_t state = 0; //!< Internal state variable
 };
 
-//! Helper function to avoid API breakage (TODO: update the rest of the codebase to the new API and remove this)
-inline void readSerial(HardwareSerial *hs /**< The connection to read from */,
-                       SerialData *dt /**< The SerialData to read from */) {
-	ParseState ps;
-	ps.dev = hs;
-	ps.dt = dt;
-	while (ps.update() != PSE_SUCCESS);
-}
+} // namespace elcano
+
+/*
+
+When structuring a component, follow the following skeleton:
+
+	elcano::ParseState ps;
+	elcano::SerialData dt;
+	
+	void setup() {
+		Serial1.begin(9600);
+		Serial2.begin(9600);
+		
+		ps.dt  = &dt;
+		ps.dev = &Serial1;
+		dt.clear();
+		
+		// Any other initialization code goes here
+	}
+	
+	void loop() {
+		elcano::ParseStateError r = ps.update();
+		if (r == elcano::ParseStateError::success) {
+			if (dt.kind == elcano::MsgType::DESIRED_TYPE) {
+				// Update code here that depends on having recieved a data set
+			} else {
+				dt.write(&Serial2);
+			}
+		}
+		
+		// Update code here that does not depend on having received a data set
+	}
+
+Replace `DESIRED_TYPE` with {`drive`, `sensor`, `goal`, `seg`} depending on your component.
+
+This ensures that we are sending data around the vehicle in a complete loop.
+	
+*/


### PR DESCRIPTION
This is a change that I've been wanting to make for a while, as it simply changes the API to be more modern and typesafe. I also took this opportunity to add some proper usage documentation to the Elcano_Serial.h file.