### PR TITLE
Latest Low Level sketch and Settings.h

### DIFF
--- a/Elcano_C2_LowLevel/Elcano_C2_LowLevel.ino
+++ b/Elcano_C2_LowLevel/Elcano_C2_LowLevel.ino
@@ -71,9 +71,10 @@ int Left_Max_Count = 980;
 int Right_Min_Count = 698;
 int Right_Max_Count = 808;
 
-double SteerAngle_wms = STRAIGHT_TURN_OUT; //Steering angle in microseconds used by writeMicroseconds function. Note: doubles on Arduinos are the same thing as floats, 4bytes, single precision
+// TCF 6/27/17  Why is steering angle in milliseconds? Degrees would be more appropriate.
+double SteerAngle_wms = STRAIGHT_TURN_MS; //Steering angle in microseconds used by writeMicroseconds function. Note: doubles on Arduinos are the same thing as floats, 4bytes, single precision
 double PIDSteeringOutput; //Output from steerPID.Compute() in microseconds (used by Servo.writeMicroseconds())
-double desiredAngle = STRAIGHT_TURN_OUT;
+double desiredAngle = STRAIGHT_TURN_MS;
 double steeringP = 1.5;
 double steeringI = 1.35; 
 double steeringD = .005;
@@ -117,7 +118,7 @@ int  brake_control = MIN_BRAKE_OUT;
 int  steer_control = STRAIGHT_TURN_OUT;
 float Odometer_m = 0;
 float HubSpeed_kmPh;
-const float  HubSpeed2kmPh = 13000000;
+//const float  HubSpeed2kmPh = 13000000;
 const unsigned long HubAtZero = 1159448;
 
 // Time at which this loop pass should end in order to maintain a
@@ -415,7 +416,7 @@ void computeAngle(){
 // Precondition: None
 // Postcondition: None
 void calibrateSensors(){
-  STEER_SERVO.writeMicroseconds(LEFT_TURN_OUT); //Calibrate angle sensors for left turn
+  STEER_SERVO.writeMicroseconds(LEFT_TURN_MS); //Calibrate angle sensors for left turn
   delay(4000);
   leftsenseleft = analogRead(A2);
   rightsenseleft = analogRead(A3);
@@ -423,7 +424,7 @@ void calibrateSensors(){
   Serial.print(leftsenseleft);
   Serial.println(rightsenseleft);
   
-  STEER_SERVO.writeMicroseconds(RIGHT_TURN_OUT); //Calibrate angle sensors for right turn
+  STEER_SERVO.writeMicroseconds(RIGHT_TURN_MS); //Calibrate angle sensors for right turn
   delay(4000);
   leftsenseright = analogRead(A2);
   rightsenseright = analogRead(A3);
@@ -502,7 +503,7 @@ byte processRC()
 // PostCondition: Return true if autonomous and false otherwise
 boolean isAutomatic(){
     if(RC_Done[RC_BRAKE]){
-      if(RC_elapsed[RC_BRAKE] > MIDDLE + TICK_DEADZONE){
+      if(RC_elapsed[RC_BRAKE] > MIDDLE + DEAD_ZONE){
         return true;           // It is manual control and not autonomous control
       }
     }
@@ -519,7 +520,7 @@ void doManualMovement(){
     //TODO: if less than the middle, reverse, otherwise forward
     bool doFeather = false;
     bool on = checkEbrake();
-    if(RC_Done[RC_GO]&& !on)
+    if(RC_Done[RC_GO] && !on)
     {
       if(RC_elapsed[RC_GO] > MIDDLE +  2 * DEAD_ZONE){
         moveVehicle(convertThrottle(RC_elapsed[RC_GO]));
@@ -539,7 +540,6 @@ void doManualMovement(){
 //Converts RC values to corresponding values for the PWM output
 int convertTurn(int input)
 {
-  
   long int steerRange, rcRange;
   long output;
   int trueOut;
@@ -550,10 +550,10 @@ int convertTurn(int input)
   }
   // On SPEKTRUM, MIN_RC = 1 msec = stick right; MAX_RC = 2 msec = stick left
   // On HI_TEC, MIN_RC = 1 msec = stick left; MAX_RC = 2 msec = stick right
-  // LEFT_TURN_OUT > RIGHT_TURN_OUT
+  // LEFT_TURN_MS > RIGHT_TURN_MS
   else
   {
-    int value = map(input, MIN_RCSTEER, MAX_RCSTEER, RIGHT_TURN_OUT, LEFT_TURN_OUT);
+    int value = map(input, MIN_RC, MAX_RC, RIGHT_TURN_OUT, LEFT_TURN_OUT);
     return value;
   }
   // @ToDo: Fix this so it is correct in any case.
@@ -579,7 +579,7 @@ int convertDeg(int deg)
 // Precondition: MIDDLE + 2 * DEAD_ZONE < input < MAX_RCGO
 int convertThrottle(int input)
 {
-  int mapping = map(input, MIDDLE + 2 * DEAD_ZONE, MAX_RCGO, 80, 140);
+  int mapping = map(input, MIDDLE + 2 * DEAD_ZONE, MAX_RC, 80, 140);
   return mapping;
 }
 
@@ -920,7 +920,7 @@ float mapThrottle(int value){
     return 0;// in future, add reverse
   }
   else
-    return map(value, MIDDLE-DEAD_ZONE, MIN_RC, 0, MAX_SPEED);
+    return map(value, MIDDLE-DEAD_ZONE, MIN_RC, 0, MAX_SPEED_KPH);
 }
 
 /*-----------------------------------ThrottlePID------------------------------------*/

--- a/TestArchive/MoveActuator/MoveActuator.ino
+++ b/TestArchive/MoveActuator/MoveActuator.ino
@@ -165,7 +165,7 @@ const int MinimumThrottle = MIN_ACC_OUT;  // Throttle has no effect until 1.2 V
 // Vehicles #1 and #2 are reversed.
 // On #1. the actuator pushes the brake lever to bake.
 // On #2, the actuator pulls on the brake cable to brake.
-const int FullBrake = MIN_BRAKE_OUT;  
+const int FullBrake = MIN_BRAKE_OUT;  // FLIP THESE TWO
 const int NoBrake = MAX_BRAKE_OUT;
 // Steering
 const int HardLeft = LEFT_TURN_OUT;
@@ -266,12 +266,13 @@ void loop()
     if (BrakePosition > NoBrake || BrakePosition < FullBrake)
         BrakeIncrement = -BrakeIncrement;
     moveBrake(BrakePosition);
+      //moveBrake(250);
 #endif  // BRAKE_RAMP  
   
  // apply steering
 #ifdef STEER_RAMP
     SteerPosition += SteerIncrement;
-    if (SteerPosition > HardLeft || SteerPosition < HardRight)
+    if (SteerPosition > HardRight || SteerPosition < HardLeft)
         SteerIncrement = -SteerIncrement;
     moveSteer(SteerPosition);
 #endif  // Steer_RAMP

--- a/libraries/Settings/Settings.h
+++ b/libraries/Settings/Settings.h
@@ -5,7 +5,7 @@
 Settings.h is a site-specific set of trike parameters.
 The file SettingsTemplate.h provides examples of how to define parameters,
 and shows the necessary parameters.
-Only Settings.h should be included from sketches.
+Only Settings.h should be included from sketches, but not saved in the git repository.
 Only SettingsTemplate.h should be saved in the git repository.
 
 After downloading the elcano repository for the first time, copy
@@ -24,28 +24,31 @@ VEHICLE_NUMBER to your own new number.
 #if (VEHICLE_NUMBER == 1)
 
 // Parameters used by Elcano_C2_LowLevel
-#define RC_SPEKTRUM
+#define RC_SPEKTRUM 
 #undef  RC_HITEC
 
-// Values (0-255) represent digital values that get convered into PWM signals by analogWrite.
+// Values (0-255) represent digital values that are PWM signals used by analogWrite.
 
 // MIN and MAX ACC set the minimum signal to get the motor going, and maximum allowable acceleration for the motor
 #define MIN_ACC_OUT 50
 #define MAX_ACC_OUT 235
 
 // MIN and MAX BRAKE_OUT set values to be sent to the brake actuator that controls the brakes on the front wheels
-#define MIN_BRAKE_OUT 1700
-#define MAX_BRAKE_OUT 2000
+#define MIN_BRAKE_OUT 202
+#define MAX_BRAKE_OUT 250
 
 // RIGHT, STRAIGHT, and LEFT TURN_OUT set values to be sent to the steer actuator that changes the direction of the front wheels
-#define RIGHT_TURN_OUT 1000
-#define LEFT_TURN_OUT 2000
-#define STRAIGHT_TURN_OUT 1500
+#define RIGHT_TURN_OUT 229
+#define LEFT_TURN_OUT 127
+#define STRAIGHT_TURN_OUT 178
 
-#define TURN_CIRCUMFERENCE_CM 96 * PI
+// RIGHT, STRAIGHT, and LEFT TURN_MS are pulse widths in msec received from the RC controller
+#define RIGHT_TURN_MS 1000
+#define LEFT_TURN_MS 2000
+#define STRAIGHT_TURN_MS 1500
 
 // Turn sensors are believed if they are in this range while wheels are straight
-// MAX values here are for the safety of the actuator so as not to break/overload it
+// These numbers vary considerably, depending on which sensor angle is set to straight.
 #define RIGHT_MIN_COUNT 80
 #define RIGHT_MAX_COUNT 284
 #define LEFT_MIN_COUNT  80
@@ -55,14 +58,15 @@ VEHICLE_NUMBER to your own new number.
 // Output to motor actuator
 #define DAC_CHANNEL 0
 // Output to steer actuator
-#define STEER_OUT_PIN 7
+#define STEER_OUT_PIN 9
 // Output to brake actuator
 #define BRAKE_OUT_PIN 6
+// DISK_BRAKE is deprecated, use BRAKE_OUT_PIN
 
 // Trike-specific physical parameters
-#define WHEEL_DIAMETER_MM 20
-// Wheel Cirumference
-#define WHEEL_CIRCUM_MM WHEEL_DIAMETER_MM * PI
+#define WHEEL_DIAMETER_MM 482
+// Wheel Circumference
+#define WHEEL_CIRCUM_MM (long) (WHEEL_DIAMETER_MM * PI)
 //		Turning radius in cm.
 #define TURN_RADIUS_CM 209
 //		Turning speed in degrees per ms.
@@ -74,24 +78,8 @@ VEHICLE_NUMBER to your own new number.
 //	Motor
 #define MOTOR_POLE_PAIRS 23
 // maximum allowed speed
-#define MAX_SPEED 15
+#define MAX_SPEED_KPH 15
 
-// Autonomous ticks
-#define TICK1 1624
-#define TICK2 1764
-#define TICK3 1900
-
-#define MIDDLE_STEER 1400		//Check to make sure this is correct
-#define MIN_RCSTEER 1100		// Check to make sure this is correct
-#define MAX_RCSTEER 1640		// Check to make sure this is correct
-
-#define MAX_RCGO 2100			// Check to make sure this is correct
-// Inaccuracy
-#define TICK_DEADZONE 40
-
-// Parameters used by MoveActuator
-// external PWM output
-// DISK_BRAKE is deprecated, use BRAKE_OUT_PIN
 // Use DAC A
 #define THROTTLE_CHANNEL 0
 
@@ -110,10 +98,10 @@ VEHICLE_NUMBER to your own new number.
 // The assignment of pins used for inputs from the RC controller
 // might differ depending on the trike.
 #define IRPT_RVS 2
-#define IRPT_TURN 21
+#define IRPT_TURN 21 
 #define IRPT_GO 19
 //EStop is bound to Channel 5, the red switch on the left side of the controller
-//Designed to be toggled on when we want to brake and
+//Designed to be toggled on when we want to brake and 
 #define IRPT_ESTOP 20
 // RDR is used for use this interrupt for the motor
 // phase feedback, which gives speed.
@@ -131,20 +119,15 @@ VEHICLE_NUMBER to your own new number.
 #define RC_MOTOR_FEEDBACK RC_RVS
 #define IRPT_MOTOR_FEEDBACK IRPT_RVS
 
-//PID parameters
-#define P_TUNE 0.4
-#define I_TUNE 0.5
-#define D_TUNE 0.1
-
 #endif
 
 #if (VEHICLE_NUMBER == 2)
 
 // Parameters used by Elcano_C2_LowLevel
-#undef RC_SPEKTRUM
+#undef RC_SPEKTRUM 
 #define  RC_HITEC
 
-// Values (0-255) represent digital values that get convered into PWM signals by analogWrite.
+// Values (0-255) represent digital values that get converted into PWM signals by analogWrite.
 
 // MIN and MAX ACC set the minimum signal to get the motor going, and maximum allowable acceleration for the motor
 #define MIN_ACC_OUT 50
@@ -156,11 +139,10 @@ VEHICLE_NUMBER to your own new number.
 
 // RIGHT, STRAIGHT, and LEFT TURN_OUT set values to be sent to the steer actuator that changes the direction of the front wheels
 #define RIGHT_TURN_OUT 128
-#define LEFT_TURN_OUT 254
+#define LEFT_TURN_OUT 254 
 #define STRAIGHT_TURN_OUT 192
 
 // Turn sensors are believed if they are in this range while wheels are straight
-// MAX values here are for the safety of the actuator so as not to break/overload it
 #define RIGHT_MIN_COUNT 725
 #define RIGHT_MAX_COUNT 785
 #define LEFT_MIN_COUNT  880
@@ -175,7 +157,7 @@ VEHICLE_NUMBER to your own new number.
 
 // Trike specific physical parameters
 #define WHEEL_DIAMETER_MM 500
-// Wheel Cirumference
+// Wheel Circumference
 #define WHEEL_CIRCUM_MM WHEEL_DIAMETER_MM * PI
 //Turning radius in cm.
 #define TURN_RADIUS 214
@@ -189,10 +171,10 @@ VEHICLE_NUMBER to your own new number.
 
 // Parameters used by RC_Control_interrupts
 #define RC_AUTO 1
-#define RC_ESTP 2//
+#define RC_ESTP 2
 #define RC_RDR  3
-#define RC_GO   4//
-#define RC_TURN 5//
+#define RC_GO   4
+#define RC_TURN 5
 // Controller has no channel for RC_AUTO
 // Reverse, not used on vehicle 2
 #define RC_RVS  6
@@ -246,26 +228,24 @@ VEHICLE_NUMBER to your own new number.
 // in the stick mechanism. We may need a calibration procedure to run periodically.
 // Since changes in these values are ephemral, changes should not be made here,
 // but only in Settings.h.
-// RC input values - pulse widths in microseconds
-#define DEAD_ZONE 75
+// RC input values - pulse widths in milliseconds
+#define DEAD_ZONE 40
 // was 1322; new stable value = 1510
-#define MIDDLE 1760
-// extremes of RC pulse width
+#define MIDDLE 1510
+// extremes of RC pulse width in millisec
 // was 911:
-#define MIN_RC 1076
+#define MIN_RC 1090
 // was 1730:
-#define MAX_RC 1908
-
-#define AUTOMATIC_MIDDLE 1460
+#define MAX_RC 1930
 
 #endif
 
 #ifdef RC_HITEC
 
-// RC input values - pulse widths in microseconds
-#define DEAD_ZONE 75
+// RC input values - pulse widths in milliseconds
+#define DEAD_ZONE 40
 #define MIDDLE 1380
-// extremes of RC pulse width
+// extremes of RC pulse width in millisec
 #define MIN_RC 960
 #define MAX_RC 1800
 

--- a/libraries/Settings/Settings.h
+++ b/libraries/Settings/Settings.h
@@ -36,6 +36,8 @@ VEHICLE_NUMBER to your own new number.
 // MIN and MAX BRAKE_OUT set values to be sent to the brake actuator that controls the brakes on the front wheels
 #define MIN_BRAKE_OUT 202
 #define MAX_BRAKE_OUT 250
+#define MIN_BRAKE_MS 1250 
+#define MAX_BRAKE_MS 1980 
 
 // RIGHT, STRAIGHT, and LEFT TURN_OUT set values to be sent to the steer actuator that changes the direction of the front wheels
 #define RIGHT_TURN_OUT 229
@@ -43,9 +45,9 @@ VEHICLE_NUMBER to your own new number.
 #define STRAIGHT_TURN_OUT 178
 
 // RIGHT, STRAIGHT, and LEFT TURN_MS are pulse widths in msec received from the RC controller
-#define RIGHT_TURN_MS 1000
-#define LEFT_TURN_MS 2000
-#define STRAIGHT_TURN_MS 1500
+#define RIGHT_TURN_MS 1100
+#define LEFT_TURN_MS 2100
+#define STRAIGHT_TURN_MS 1600
 
 // Turn sensors are believed if they are in this range while wheels are straight
 // These numbers vary considerably, depending on which sensor angle is set to straight.

--- a/libraries/Settings/Settings.h
+++ b/libraries/Settings/Settings.h
@@ -34,20 +34,22 @@ VEHICLE_NUMBER to your own new number.
 #define MAX_ACC_OUT 235
 
 // MIN and MAX BRAKE_OUT set values to be sent to the brake actuator that controls the brakes on the front wheels
-#define MIN_BRAKE_OUT 202
-#define MAX_BRAKE_OUT 250
-#define MIN_BRAKE_MS 1250 
-#define MAX_BRAKE_MS 1980 
+#define MIN_BRAKE_OUT 160
+#define MAX_BRAKE_OUT 207
+#define MIN_BRAKE_US 1450  // ex. MIN_BRAKE_MS
+#define MAX_BRAKE_US 1980  // ex. MAX_BRAKE_MS
 
 // RIGHT, STRAIGHT, and LEFT TURN_OUT set values to be sent to the steer actuator that changes the direction of the front wheels
-#define RIGHT_TURN_OUT 229
-#define LEFT_TURN_OUT 127
-#define STRAIGHT_TURN_OUT 178
+#define RIGHT_TURN_OUT 240
+#define LEFT_TURN_OUT 50
+#define STRAIGHT_TURN_OUT 196
 
 // RIGHT, STRAIGHT, and LEFT TURN_MS are pulse widths in msec received from the RC controller
-#define RIGHT_TURN_MS 1100
-#define LEFT_TURN_MS 2100
-#define STRAIGHT_TURN_MS 1600
+#define WHEEL_MAX_LEFT_US 1000  // ex. RIGHT_TURN_OUT
+#define WHEEL_MAX_RIGHT_US 1900  // ex. LEFT_TURN_OUT
+#define WHEEL_STRAIGHT_US 1415  // ex. STRAIGHT_TURN_OUT
+
+#define WHEEL_STRAIGHT_SENSOR 515
 
 // Turn sensors are believed if they are in this range while wheels are straight
 // These numbers vary considerably, depending on which sensor angle is set to straight.
@@ -60,7 +62,7 @@ VEHICLE_NUMBER to your own new number.
 // Output to motor actuator
 #define DAC_CHANNEL 0
 // Output to steer actuator
-#define STEER_OUT_PIN 9
+#define STEER_OUT_PIN 7
 // Output to brake actuator
 #define BRAKE_OUT_PIN 6
 // DISK_BRAKE is deprecated, use BRAKE_OUT_PIN
@@ -231,21 +233,28 @@ VEHICLE_NUMBER to your own new number.
 // Since changes in these values are ephemral, changes should not be made here,
 // but only in Settings.h.
 // RC input values - pulse widths in milliseconds
-#define DEAD_ZONE 40
+#define DEAD_ZONE 75
 // was 1322; new stable value = 1510
 #define MIDDLE 1510
 // extremes of RC pulse width in millisec
 // was 911:
 #define MIN_RC 1090
+#define MAX_RC 1900
+
+#define MIN_TURN_RC 1084
+#define MIN_THROTTLE_RC 1444
 // was 1730:
-#define MAX_RC 1930
+#define MAX_THROTTLE_RC 2060
+#define MAX_TURN_RC 1916
+
+#define MIN_BRAKE_RC 1096
 
 #endif
 
 #ifdef RC_HITEC
 
 // RC input values - pulse widths in milliseconds
-#define DEAD_ZONE 40
+#define DEAD_ZONE 75
 #define MIDDLE 1380
 // extremes of RC pulse width in millisec
 #define MIN_RC 960

--- a/libraries/Settings/SettingsTemplate.h
+++ b/libraries/Settings/SettingsTemplate.h
@@ -5,7 +5,7 @@
 Settings.h is a site-specific set of trike parameters.
 The file SettingsTemplate.h provides examples of how to define parameters,
 and shows the necessary parameters.
-Only Settings.h should be included from sketches.
+Only Settings.h should be included from sketches, but not saved in the git repository.
 Only SettingsTemplate.h should be saved in the git repository.
 
 After downloading the elcano repository for the first time, copy
@@ -27,23 +27,28 @@ VEHICLE_NUMBER to your own new number.
 #define RC_SPEKTRUM 
 #undef  RC_HITEC
 
-// Values (0-255) represent digital values that get convered into PWM signals by analogWrite.
+// Values (0-255) represent digital values that are PWM signals used by analogWrite.
 
 // MIN and MAX ACC set the minimum signal to get the motor going, and maximum allowable acceleration for the motor
 #define MIN_ACC_OUT 50
 #define MAX_ACC_OUT 235
 
 // MIN and MAX BRAKE_OUT set values to be sent to the brake actuator that controls the brakes on the front wheels
-#define MIN_BRAKE_OUT 160
-#define MAX_BRAKE_OUT 207
+#define MIN_BRAKE_OUT 202
+#define MAX_BRAKE_OUT 250
 
 // RIGHT, STRAIGHT, and LEFT TURN_OUT set values to be sent to the steer actuator that changes the direction of the front wheels
-#define RIGHT_TURN_OUT 1000
-#define LEFT_TURN_OUT 2000
-#define STRAIGHT_TURN_OUT 1500
+#define RIGHT_TURN_OUT 229
+#define LEFT_TURN_OUT 127
+#define STRAIGHT_TURN_OUT 178
+
+// RIGHT, STRAIGHT, and LEFT TURN_MS are pulse widths in msec received from the RC controller
+#define RIGHT_TURN_MS 1000
+#define LEFT_TURN_MS 2000
+#define STRAIGHT_TURN_MS 1500
 
 // Turn sensors are believed if they are in this range while wheels are straight
-// MAX values here are for the safety of the actuator so as not to break/overload it
+// These numbers vary considerably, depending on which sensor angle is set to straight.
 #define RIGHT_MIN_COUNT 80
 #define RIGHT_MAX_COUNT 284
 #define LEFT_MIN_COUNT  80
@@ -53,14 +58,15 @@ VEHICLE_NUMBER to your own new number.
 // Output to motor actuator
 #define DAC_CHANNEL 0
 // Output to steer actuator
-#define STEER_OUT_PIN 7
+#define STEER_OUT_PIN 9
 // Output to brake actuator
 #define BRAKE_OUT_PIN 6
+// DISK_BRAKE is deprecated, use BRAKE_OUT_PIN
 
 // Trike-specific physical parameters
 #define WHEEL_DIAMETER_MM 482
-// Wheel Cirumference
-#define WHEEL_CIRCUM_MM WHEEL_DIAMETER_MM * PI
+// Wheel Circumference
+#define WHEEL_CIRCUM_MM (long) (WHEEL_DIAMETER_MM * PI)
 //		Turning radius in cm.
 #define TURN_RADIUS_CM 209
 //		Turning speed in degrees per ms.
@@ -71,10 +77,9 @@ VEHICLE_NUMBER to your own new number.
 #define TURN_MAX_DEG 30
 //	Motor
 #define MOTOR_POLE_PAIRS 23
+// maximum allowed speed
+#define MAX_SPEED_KPH 15
 
-// Parameters used by MoveActuator
-// external PWM output
-// DISK_BRAKE is deprecated, use BRAKE_OUT_PIN
 // Use DAC A
 #define THROTTLE_CHANNEL 0
 
@@ -122,7 +127,7 @@ VEHICLE_NUMBER to your own new number.
 #undef RC_SPEKTRUM 
 #define  RC_HITEC
 
-// Values (0-255) represent digital values that get convered into PWM signals by analogWrite.
+// Values (0-255) represent digital values that get converted into PWM signals by analogWrite.
 
 // MIN and MAX ACC set the minimum signal to get the motor going, and maximum allowable acceleration for the motor
 #define MIN_ACC_OUT 50
@@ -138,7 +143,6 @@ VEHICLE_NUMBER to your own new number.
 #define STRAIGHT_TURN_OUT 192
 
 // Turn sensors are believed if they are in this range while wheels are straight
-// MAX values here are for the safety of the actuator so as not to break/overload it
 #define RIGHT_MIN_COUNT 725
 #define RIGHT_MAX_COUNT 785
 #define LEFT_MIN_COUNT  880
@@ -153,7 +157,7 @@ VEHICLE_NUMBER to your own new number.
 
 // Trike specific physical parameters
 #define WHEEL_DIAMETER_MM 500
-// Wheel Cirumference
+// Wheel Circumference
 #define WHEEL_CIRCUM_MM WHEEL_DIAMETER_MM * PI
 //Turning radius in cm.
 #define TURN_RADIUS 214
@@ -224,11 +228,11 @@ VEHICLE_NUMBER to your own new number.
 // in the stick mechanism. We may need a calibration procedure to run periodically.
 // Since changes in these values are ephemral, changes should not be made here,
 // but only in Settings.h.
-// RC input values - pulse widths in microseconds
+// RC input values - pulse widths in milliseconds
 #define DEAD_ZONE 75
 // was 1322; new stable value = 1510
 #define MIDDLE 1510
-// extremes of RC pulse width
+// extremes of RC pulse width in millisec
 // was 911:
 #define MIN_RC 1090
 // was 1730:
@@ -238,10 +242,10 @@ VEHICLE_NUMBER to your own new number.
 
 #ifdef RC_HITEC
 
-// RC input values - pulse widths in microseconds
+// RC input values - pulse widths in milliseconds
 #define DEAD_ZONE 75
 #define MIDDLE 1380
-// extremes of RC pulse width
+// extremes of RC pulse width in millisec
 #define MIN_RC 960
 #define MAX_RC 1800
 

--- a/libraries/Settings/SettingsTemplate.h
+++ b/libraries/Settings/SettingsTemplate.h
@@ -36,6 +36,8 @@ VEHICLE_NUMBER to your own new number.
 // MIN and MAX BRAKE_OUT set values to be sent to the brake actuator that controls the brakes on the front wheels
 #define MIN_BRAKE_OUT 202
 #define MAX_BRAKE_OUT 250
+#define MIN_BRAKE_MS 1250 
+#define MAX_BRAKE_MS 1980 
 
 // RIGHT, STRAIGHT, and LEFT TURN_OUT set values to be sent to the steer actuator that changes the direction of the front wheels
 #define RIGHT_TURN_OUT 229
@@ -43,9 +45,9 @@ VEHICLE_NUMBER to your own new number.
 #define STRAIGHT_TURN_OUT 178
 
 // RIGHT, STRAIGHT, and LEFT TURN_MS are pulse widths in msec received from the RC controller
-#define RIGHT_TURN_MS 1000
-#define LEFT_TURN_MS 2000
-#define STRAIGHT_TURN_MS 1500
+#define RIGHT_TURN_MS 1100
+#define LEFT_TURN_MS 2100
+#define STRAIGHT_TURN_MS 1600
 
 // Turn sensors are believed if they are in this range while wheels are straight
 // These numbers vary considerably, depending on which sensor angle is set to straight.
@@ -134,8 +136,10 @@ VEHICLE_NUMBER to your own new number.
 #define MAX_ACC_OUT 227
 
 // MIN and MAX BRAKE_OUT set values to be sent to the brake actuator that controls the brakes on the front wheels
-#define MIN_BRAKE_OUT 128
-#define MAX_BRAKE_OUT 254
+#define MIN_BRAKE_OUT 202
+#define MAX_BRAKE_OUT 250
+#define MIN_BRAKE_MS 1250 
+#define MAX_BRAKE_MS 1980 
 
 // RIGHT, STRAIGHT, and LEFT TURN_OUT set values to be sent to the steer actuator that changes the direction of the front wheels
 #define RIGHT_TURN_OUT 128

--- a/libraries/Settings/SettingsTemplate.h
+++ b/libraries/Settings/SettingsTemplate.h
@@ -34,20 +34,22 @@ VEHICLE_NUMBER to your own new number.
 #define MAX_ACC_OUT 235
 
 // MIN and MAX BRAKE_OUT set values to be sent to the brake actuator that controls the brakes on the front wheels
-#define MIN_BRAKE_OUT 202
-#define MAX_BRAKE_OUT 250
-#define MIN_BRAKE_MS 1250 
-#define MAX_BRAKE_MS 1980 
+#define MIN_BRAKE_OUT 160
+#define MAX_BRAKE_OUT 207
+#define MIN_BRAKE_US 1250  // ex. MIN_BRAKE_MS
+#define MAX_BRAKE_US 1980  // ex. MAX_BRAKE_MS
 
 // RIGHT, STRAIGHT, and LEFT TURN_OUT set values to be sent to the steer actuator that changes the direction of the front wheels
-#define RIGHT_TURN_OUT 229
-#define LEFT_TURN_OUT 127
-#define STRAIGHT_TURN_OUT 178
+#define RIGHT_TURN_OUT 240
+#define LEFT_TURN_OUT 140
+#define STRAIGHT_TURN_OUT 196
 
 // RIGHT, STRAIGHT, and LEFT TURN_MS are pulse widths in msec received from the RC controller
-#define RIGHT_TURN_MS 1100
-#define LEFT_TURN_MS 2100
-#define STRAIGHT_TURN_MS 1600
+#define WHEEL_MAX_LEFT_US 1000  // ex. RIGHT_TURN_OUT
+#define WHEEL_MAX_RIGHT_US 2000  // ex. LEFT_TURN_OUT
+#define WHEEL_STRAIGHT_US 1500  // ex. STRAIGHT_TURN_OUT
+
+#define WHEEL_STRAIGHT_SENSOR 350
 
 // Turn sensors are believed if they are in this range while wheels are straight
 // These numbers vary considerably, depending on which sensor angle is set to straight.
@@ -60,7 +62,7 @@ VEHICLE_NUMBER to your own new number.
 // Output to motor actuator
 #define DAC_CHANNEL 0
 // Output to steer actuator
-#define STEER_OUT_PIN 9
+#define STEER_OUT_PIN 7
 // Output to brake actuator
 #define BRAKE_OUT_PIN 6
 // DISK_BRAKE is deprecated, use BRAKE_OUT_PIN
@@ -136,10 +138,8 @@ VEHICLE_NUMBER to your own new number.
 #define MAX_ACC_OUT 227
 
 // MIN and MAX BRAKE_OUT set values to be sent to the brake actuator that controls the brakes on the front wheels
-#define MIN_BRAKE_OUT 202
-#define MAX_BRAKE_OUT 250
-#define MIN_BRAKE_MS 1250 
-#define MAX_BRAKE_MS 1980 
+#define MIN_BRAKE_OUT 128
+#define MAX_BRAKE_OUT 254
 
 // RIGHT, STRAIGHT, and LEFT TURN_OUT set values to be sent to the steer actuator that changes the direction of the front wheels
 #define RIGHT_TURN_OUT 128
@@ -155,7 +155,7 @@ VEHICLE_NUMBER to your own new number.
 // Trike specific pins/channels
 #define DAC_CHANNEL 0
 // Output to steer actuator
-#define STEER_OUT_PIN 7
+#define STEER_OUT_PIN 9
 // Output to brake actuator
 #define BRAKE_OUT_PIN 8
 


### PR DESCRIPTION
Low Level Updates:
Big restructuring, but many things were still kept from old version, and some are currently unused. Fixed steering problems and correct mapping (fully working). Fixed RC controls (fully working). Added steering calibration for max left and right values, and middle RC signal value calibration whenever RC is turned on. Added capability to manipulate the brake with the joystick, which later can be used for reverse.
To Do: Loop function timer and order of execution. Double check it correctly reports back to C6. Insert turn values from High Level in function for processing High Level turn input and do conversion. PID for throttle and steering. Cleanup unnecessary testing code.

Settings.h Updates:
Added needed constants for brake, steering, and RC signals. Reworded and modified some previous constants.
