### PR TITLE
Update ElcanoSerial

### DIFF
--- a/Elcano_C2_LowLevel/Elcano_C2_LowLevel.ino
+++ b/Elcano_C2_LowLevel/Elcano_C2_LowLevel.ino
@@ -352,49 +352,49 @@ void loop()
   static bool e_stop = 0, auto_mode = 0;
   brake.Check();
 
-// get data from serial
-// get desired steering and speed
-   if (auto_mode)
-   {
-   // Receiving data from High Level 
-     ParseStateError r = RxStateHiLevel.update();
-     if (r == ParseStateError::success) {
-       desired_speed_cmPs = RxDataHiLevel.speed_cmPs; 
-       desired_angle = RxDataHiLevel.angle_deg; 
-     } 
-   }
-    computeSpeed(&history);
-    computeAngle(); // TO DO: Convert angle to right units for PID and for sending to High Level.
-    
-    // Write data to High Level
-    TxDataHiLevel.speed_cmPs = (speedCyclometerInput_mmPs + 5) / 10;
-    TxDataHiLevel.write(TxStateHiLevel.output);
-
-    // Get data from RC unit
-    ParseStateError r = RC_State.update();
+  // get data from serial
+  // get desired steering and speed
+  if (auto_mode)
+  {
+    // Receiving data from High Level
+    ParseStateError r = RxStateHiLevel.update();
     if (r == ParseStateError::success) {
-      e_stop = RC_Data.number & 0x01;
-      auto_mode = RC_Data.number & 0x02;
-      if (!auto_mode)
-      {
-        desired_speed_cmPs = RC_Data.speed_cmPs; 
-        desired_angle = RC_Data.angle_deg; 
-      }
-    } 
-    if (e_stop)
+      desired_speed_cmPs = RxDataHiLevel.speed_cmPs;
+      desired_angle = RxDataHiLevel.angle_mDeg;
+    }
+  }
+  computeSpeed(&history);
+  computeAngle(); // TO DO: Convert angle to right units for PID and for sending to High Level.
+  
+  // Write data to High Level
+  TxDataHiLevel.speed_cmPs = (speedCyclometerInput_mmPs + 5) / 10;
+  TxDataHiLevel.write(TxStateHiLevel.output);
+
+  // Get data from RC unit
+  ParseStateError r = RC_State.update();
+  if (r == ParseStateError::success) {
+    e_stop = RC_Data.number & 0x01;
+    auto_mode = RC_Data.number & 0x02;
+    if (!auto_mode)
     {
-      brake.Stop();
-      engageWheel(0); // Turn off wheel
+      desired_speed_cmPs = RC_Data.speed_cmPs; 
+      desired_angle = RC_Data.angle_mDeg; 
     }
-    else
-    { // Control trike to desired speed and angle 
-      SteeringPID(convertHLToTurn(desired_angle));
-      ThrottlePID(desired_speed_cmPs);
-    }
-    
+  } 
+  if (e_stop)
+  {
+    brake.Stop();
+    engageWheel(0); // Turn off wheel
+  }
+  else
+  { // Control trike to desired speed and angle 
+    SteeringPID(convertHLToTurn(desired_angle));
+    ThrottlePID(desired_speed_cmPs);
+  }
+
   // DO NOT INSERT ANY LOOP CODE BELOW THIS POINT !!
 
-   unsigned long delay_ms = millis() - (timeStart_ms + LOOP_TIME_MS);
+  unsigned long delay_ms = millis() - (timeStart_ms + LOOP_TIME_MS);
   // Did we spend long enough in the loop that we should immediately start
   // the next pass?
   if(delay_ms > 0L)

--- a/Elcano_C2_LowLevel/Elcano_C2_LowLevel_TimedBrakes/Elcano_C2_LowLevel_TimedBrakes.ino
+++ b/Elcano_C2_LowLevel/Elcano_C2_LowLevel_TimedBrakes/Elcano_C2_LowLevel_TimedBrakes.ino
@@ -340,7 +340,7 @@ void loop() {
 
   // @ToDo: What is this doing?
   Results.kind = MsgType::sensor;
-  Results.angle_deg = TurnAngle_degx10() / 10;
+  Results.angle_mDeg = TurnAngle_degx10() / 10;
   // @ToDo: Is this working and should it be uncommented?
   
   calibrationTime_ms += LOOP_TIME_MS;
@@ -462,7 +462,7 @@ void LogData(unsigned long commands[7], SerialData *sensors)  // data for spread
   Serial.print(sensors->speed_cmPs); Serial.print("\t");             //(cm/s) Speed
   Serial.print(sensors->speed_cmPs * 36.0 / 1000.); Serial.print("\t"); //(km/h) Speed
   Serial.print(HubSpeed_kmPh); Serial.print("\t");                   //(km/h) Hub Speed
-  Serial.print(sensors->angle_deg); Serial.print("\t");              //(deg) Angle
+  Serial.print(sensors->angle_mDeg); Serial.print("\t");              //(deg) Angle
   int right = analogRead(A3);
   int left = analogRead(A2);
   Serial.print(right); Serial.print("\t");                           //Right turn sensor
@@ -709,7 +709,7 @@ void doManualMovement(){
 void processHighLevel(SerialData * results)
 {
   //Steer
-  int turn_signal = convertDeg(results->angle_deg);
+  int turn_signal = convertDeg(results->angle_mDeg);
   steer(turn_signal);
   //End Steer
   //Throttle

--- a/Elcano_C2_Tester/Elcano_C2_Tester.ino
+++ b/Elcano_C2_Tester/Elcano_C2_Tester.ino
@@ -135,7 +135,7 @@ void setup()  {
   parseState.output = &Serial3;
   Serial3.begin(baudrate);
   parseState.capture = MsgType::drive;
-  // msgType::drive uses `speed_cmPs` and `angle_deg`
+  // msgType::drive uses `speed_cmPs` and `angle_mDeg`
 
   //set up for transmitting data from C2
   SendData.clear();

--- a/Elcano_C6_Navigator/Elcano_C6_Navigator_figureoutDelay/Elcano_C6_Navigator_figureoutDelay.ino
+++ b/Elcano_C6_Navigator/Elcano_C6_Navigator_figureoutDelay/Elcano_C6_Navigator_figureoutDelay.ino
@@ -182,8 +182,8 @@ void displayResults(SerialData &Results)
 //    Serial.println(Results.number);    
 //    Serial.print("SerialData::speed_cmPs:");
 //    Serial.println(Results.speed_cmPs);
-//    Serial.print("SerialData::angle_deg:");
-//    Serial.println(Results.angle_deg);    // front wheels
+//    Serial.print("SerialData::angle_mDeg:");
+//    Serial.println(Results.angle_mDeg);    // front wheels
 //    Serial.print("SerialData::bearing_deg:");
 //    Serial.println(Results.bearing_deg);  // compass direction
 //    Serial.print("SerialData::posE_cm:");
@@ -562,7 +562,7 @@ void loop()
   data.kind = MsgType::sensor;
   data.bearing_deg = CurrentHeading;
   //C2_Results.speed_cmPs = 0;
-  //C2_Results.angle_deg = 0;
+  //C2_Results.angle_mDeg = 0;
   data.posE_cm = GPS_reading.latitude/10;
   data.posN_cm = GPS_reading.longitude/10;
 	// Read data from C2 using Elcano_Serial
@@ -616,7 +616,7 @@ void loop()
 	data.posE_cm = fuzzy_out.x_Pos;
 	data.posN_cm = fuzzy_out.y_Pos;
 	data.bearing_deg = CurrentHeading;
-	data.angle_deg = 0;
+	data.angle_mDeg = 0;
 	// data.write(&Serial2);
 //	Serial.println("\t\t\t\t\tx_Pos" + String(fuzzy_out.x_Pos) + "   y_Pos" + String(fuzzy_out.y_Pos));
   }

--- a/Elcano_C6_Navigator/NavigationCyclometer/NavigationCyclometer.ino
+++ b/Elcano_C6_Navigator/NavigationCyclometer/NavigationCyclometer.ino
@@ -254,8 +254,8 @@
 ////  Serial.println(Results.number);
 ////  Serial.print("SerialData::speed_cmPs:");
 ////  Serial.println(Results.speed_cmPs);
-////  Serial.print("SerialData::angle_deg:");
-////  Serial.println(Results.angle_deg);    // front wheels
+////  Serial.print("SerialData::angle_mDeg:");
+////  Serial.println(Results.angle_mDeg);    // front wheels
 ////  Serial.print("SerialData::bearing_deg:");
 ////  Serial.println(Results.bearing_deg);  // compass direction
 ////  Serial.print("SerialData::posE_cm:");

--- a/MoveActuator/MoveActuator.ino
+++ b/MoveActuator/MoveActuator.ino
@@ -257,7 +257,7 @@ class Brakes
 // For normal operation
 const long int loop_time_ms = 100;  // Limits time in the loop.
 
- Brakes brake = Brakes();
+Brakes brake = Brakes();
  
 
 /*---------------------------------------------------------------------------------------*/

--- a/TestArchive/Elcano_C2_LowLevel_with_test_code/Elcano_C2_LowLevel_with_test_code.ino
+++ b/TestArchive/Elcano_C2_LowLevel_with_test_code/Elcano_C2_LowLevel_with_test_code.ino
@@ -272,7 +272,7 @@ void setup()
   parseState.output = &Serial3;
   Serial3.begin(baudrate);
   parseState.capture = MsgType::drive;
-  // msgType::drive uses `speed_cmPs` and `angle_deg`
+  // msgType::drive uses `speed_cmPs` and `angle_mDeg`
   
   Results.clear();
   SpeedCyclometer_mmPs = 0;
@@ -353,7 +353,7 @@ void loop() {
   // temporary
 //  Results.speed_cmPs = 0;
   // end temporary
-  Results.angle_deg = 0;
+  Results.angle_mDeg = 0;
   Results.write(&Serial3);
  
 //  delay(100);
@@ -393,7 +393,7 @@ void loop() {
 
 //  // @ToDo: What is this doing?
 //  Results.kind = MsgType::sensor;
-//  Results.angle_deg = TurnAngle_degx10() / 10;
+//  Results.angle_mDeg = TurnAngle_degx10() / 10;
 //  // @ToDo: Is this working and should it be uncommented?
   
   calibrationTime_ms += LOOP_TIME_MS;
@@ -475,7 +475,7 @@ void processHighLevel(SerialData * results)
   Serial3.end();
   Serial3.begin(baudrate);  // clear the buffer
   
-  int turn_signal = convertDeg(results->angle_deg);
+  int turn_signal = convertDeg(results->angle_mDeg);
 
   desiredSpeed = results->speed_cmPs * 10;
   desiredAngle = turn_signal;
@@ -1410,7 +1410,7 @@ void LogData(unsigned long commands[7], SerialData *sensors)  // data for spread
   Serial.print(sensors->speed_cmPs); Serial.print("\t");             //(cm/s) Speed
   Serial.print(sensors->speed_cmPs * 36.0 / 1000.); Serial.print("\t"); //(km/h) Speed
   Serial.print(HubSpeed_kmPh); Serial.print("\t");                   //(km/h) Hub Speed
-  Serial.print(sensors->angle_deg); Serial.print("\t");              //(deg) Angle
+  Serial.print(sensors->angle_mDeg); Serial.print("\t");              //(deg) Angle
   int right = analogRead(A3);
   int left = analogRead(A2);
   Serial.print(right); Serial.print("\t");                           //Right turn sensor

--- a/TestArchive/Elcano_C3_Pilot_Test/C4_Output_Tests/C4_Output_Tests.ino
+++ b/TestArchive/Elcano_C3_Pilot_Test/C4_Output_Tests/C4_Output_Tests.ino
@@ -14,7 +14,7 @@ void loop()
   testResult.kind = 1;
   testResult.number = 2;
   testResult.speed_cmPs = 3;
-  testResult.angle_deg = 4;
+  testResult.angle_mDeg = 4;
   testResult.bearing_deg = 5;
   testResult.posE_cm = 6;
   testResult.posN_cm = 7;

--- a/TestArchive/Elcano_C3_Pilot_Test/Pilot_Motion_Tests/Pilot_Motion_Tests.ino
+++ b/TestArchive/Elcano_C3_Pilot_Test/Pilot_Motion_Tests/Pilot_Motion_Tests.ino
@@ -268,7 +268,7 @@ void loop()
 {
     //Most basic test of output to the low level
     SerialData lowLevelData;
-    lowLevelData.angle_deg = 15;
+    lowLevelData.angle_mDeg = 15;
     lowLevelData.speed_cmPs = 120;
     lowLevelData.write(&Serial1);
 

--- a/TestArchive/Elcano_C3_Unit_Tests/Elcano_C3_Unit_Tests.ino
+++ b/TestArchive/Elcano_C3_Unit_Tests/Elcano_C3_Unit_Tests.ino
@@ -625,7 +625,7 @@ void loop()
     //Send data to low level.
     SerialData toLowLevel;
     toLowLevel.kind = MSG_DRIVE;
-    toLowLevel.angle_deg = steeringAngle;
+    toLowLevel.angle_mDeg = steeringAngle;
     toLowLevel.speed_cmPs = speedSetting;
     toLowLevel.write(&Serial1);
 
@@ -645,7 +645,7 @@ void loop()
     /*
      sensorData.kind = 2;
      sensorData.speedcmPs = 100;
-     sensorData.angle_deg = 12;
+     sensorData.angle_mDeg = 12;
      sensorData.posE_cm = 50;
      sensorData.posN_cm = 50;
      sensorData.bearing_deg = 15;
@@ -655,7 +655,7 @@ void loop()
     /*
     toLowLevel.kind = 1;
     toLowLevel.speed_cmPs = 400;
-    toLowLevel.angle_deg = 35;
+    toLowLevel.angle_mDeg = 35;
      */
     
     

--- a/libraries/ElcanoSerial/ElcanoSerial.cpp
+++ b/libraries/ElcanoSerial/ElcanoSerial.cpp
@@ -67,7 +67,7 @@ STATE('G', goal)
 STATE('X', seg)
 #undef STATE
     default:
-	  mostRecent = c;
+      mostRecent = c;
       state = 0;
       return ParseStateError::bad_type;
     }
@@ -99,7 +99,7 @@ STATE('X', seg)
     case 'n': state = 3; goto start;
     case 's': state = 4; goto start;
     case 'a': state = 5; goto start;
-	case 'o': state = 6; goto start;
+    case 'o': state = 6; goto start;
     case 'b': state = 7; goto start;
     case 'r': state = 8; goto start;
     case 'p': state = 9; goto start;
@@ -346,7 +346,7 @@ bool SerialData::verify(void) {
     if (speed_cmPs  == NaN) return false;
     if (posE_cm     == NaN) return false;
     if (posN_cm     == NaN) return false;
-	if (obstacle_mm == NaN) return false;
+    if (obstacle_mm == NaN) return false;
     if (bearing_deg == NaN) return false;
     if (angle_mDeg  == NaN) return false;
     break;

--- a/libraries/ElcanoSerial/ElcanoSerial.cpp
+++ b/libraries/ElcanoSerial/ElcanoSerial.cpp
@@ -1,4 +1,7 @@
 #include "ElcanoSerial.h"
+#include <FastCRC.h>
+
+#define TERMINAL_CHAR '\n'
 
 // Elcano_Serial.h
 // By Dylan Katz
@@ -7,314 +10,270 @@
 // connections. Complete documentation and usage is on the wiki.
 namespace elcano {
 
-ParseStateError ParseState::update(void) {
-  int c;
-  int i = 0;
-  char buffer[MAX_MSG_SIZE];
-  
-  // Because no attribute type can be used for more than 1 flag, these
-  // variables keep track of whether the given attribute type has been used
-  // in a flag so far.
-  bool numberWasUsed = false;
-  bool speedWasUsed = false;
-  bool angleWasUsed = false;
-  bool obstacleWasUsed = false;
-  bool bearingWasUsed = false;
-  bool EposWasUsed = false;
-  bool NposWasUsed = false;
-  bool probabilityWasUsed = false;
-  
-  // Checksum variables
-  uint8_t checksum = 0; // checksum computed from message string
-  uint8_t msgChecksum = -1; // checksum included with the message
-  
-start:
-  if (i == MAX_MSG_SIZE) {
-    state = 0;
-    return ParseStateError::long_msg;
-  }
-  c = input->read();
-  buffer[i] = c;
-  i++;
-  if (c == -1) {
-    state = 0;
-    return ParseStateError::unavailable;
-  }
-  if (c == ' ' || c == '\t' || c == '\0' || c == '\r') goto start;
-  switch(state) {
-  case 0:
-    // During this state, we begin the processing of a new SerialData packet
-    // and we must receive {D,S,G,X} to state which type of packet we are
-    // working with. As an optimization, the user may set only a specific type
-    // of messages to capture, with all other types result in the stream being
-    // directly fed into the `output' serial port. Set the `capture' variable
-    // to do this, and use `|' to let it capture more than one type at once.
-    dt->clear();
-    switch(c) {
-#define STATE(CHR, TYPE)             \
-    case CHR:                        \
-      if (capture & MsgType::TYPE) { \
-        dt->kind = MsgType::TYPE;    \
-        state = 1;                   \
-      } else {                       \
-        output->print(CHR);          \
-        state = 50;                  \
-      }                              \
-      break;
-STATE('D', drive)
-STATE('S', sensor)
-STATE('G', goal)
-STATE('X', seg)
-#undef STATE
-    default:
-      mostRecent = c;
-      state = 0;
-      return ParseStateError::bad_type;
-    }
-    goto start;
-  case 1:
-    // During this state, we need to find '{' if we are reading the value for
-    // an attribute, or '\n' if we are done with the packet, or '-' or '1'-'9'
-    // if we are reading the checksum
-    switch(c) {
-    //case '\n': state = 0; return dt->verify() ? ParseStateError::success : ParseStateError::inval_comb;
-    case '\n': state =  0; return ParseStateError::success;
-    case '{' : state =  2; goto start;
-    case '1' :
-    case '2' :
-    case '3' :
-    case '4' :
-    case '5' :
-    case '6' :
-    case '7' :
-    case '8' :
-    case '9' : state = 40; checksum = CRC8.smbus((const uint8_t*)buffer, i - 1); msgChecksum = c - '0'; goto start;
-    case '-' : state = 41; checksum = CRC8.smbus((const uint8_t*)buffer, i - 1); goto start;
-    default  : state =  0; return ParseStateError::bad_lcurly;
-    }
-  case 2:
-    // During this state, we begin reading an attribute of the SerialData and
-    // we must recieve {n,s,a,o,b,r,p} to state _which_ attribute
-    switch(c) {
-    case 'n': state = 3; goto start;
-    case 's': state = 4; goto start;
-    case 'a': state = 5; goto start;
-    case 'o': state = 6; goto start;
-    case 'b': state = 7; goto start;
-    case 'r': state = 8; goto start;
-    case 'p': state = 9; goto start;
-    default : state = 0; return ParseStateError::bad_attrib;
-    }
-#define STATES(SS, PS, NS, TERM, HOME, VAR, BOOL) \
-  case SS:                                  \
-    if (BOOL) {                             \
-      state = 0;                            \
-      return ParseStateError::bad_attrib;   \
-    }                                       \
-    dt->VAR = 0;                            \
-    if (c == '-') {                         \
-      state = NS;                           \
-      goto start;                           \
-    }                                       \
-    state = PS;                             \
-  case PS:                                  \
-    if (c >= '0' && c <= '9') {             \
-      dt->VAR *= 10;                        \
-      dt->VAR += c - '0';                   \
-      goto start;                           \
-    } else if (c == TERM) {                 \
-      BOOL = true;                          \
-      state = HOME;                         \
-      goto start;                           \
-    } else {                                \
-      state = 0;                            \
-      return ParseStateError::bad_number;   \
-    }                                       \
-  case NS:                                  \
-    if (c >= '0' && c <= '9') {             \
-      dt->VAR *= 10;                        \
-      dt->VAR -= c - '0';                   \
-      goto start;                           \
-    } else if (c == TERM) {                 \
-      BOOL = true;                          \
-      state = HOME;                         \
-      goto start;                           \
-    } else {                                \
-      state = 0;                            \
-      return ParseStateError::bad_number;   \
-    }
-STATES( 3, 13, 23, '}',  1, number, numberWasUsed)
-STATES( 4, 14, 24, '}',  1, speed_cmPs, speedWasUsed)
-STATES( 5, 15, 25, '}',  1, angle_mDeg, angleWasUsed)
-STATES( 6, 16, 26, '}',  1, obstacle_mm, obstacleWasUsed)
-STATES( 7, 17, 27, '}',  1, bearing_deg, bearingWasUsed)
-STATES( 8, 18, 28, '}',  1, probability, probabilityWasUsed)
-STATES( 9, 19, 29, ',', 10, posE_cm, EposWasUsed)
-STATES(10, 20, 30, '}',  1, posN_cm, NposWasUsed)
-#undef STATES
-  case 40: // positive checksum
-    if (c == '\n') {
-      if (checksum != msgChecksum) {
-        state = 0;
-        return ParseStateError::bad_checksum;
-        } else {
-        state = 0;
-        return ParseStateError::success;
-        }
-    } else if (c < '0' || c > '9') {
-      return ParseStateError::bad_checksum;
+static FastCRC8 CRC8;
+
+static bool is_unavailable_byte(const uint8_t & c) {
+  return c == 255;
+}
+
+static MsgType parse_msg_type(const uint8_t & c) {
+  if (c == 'D') return MsgType::drive;
+  if (c == 'S') return MsgType::sensor;
+  if (c == 'G') return MsgType::goal;
+  if (c == 'X') return MsgType::seg;
+  return MsgType::none;
+}
+
+static int32_t* get_datum_ptr(const SerialData & dt, const uint8_t & datum_type) {
+  if (datum_type == 'n') return &(dt.number);
+  if (datum_type == 's') return &(dt.speed_cmPs);
+  if (datum_type == 'a') return &(dt.angle_mDeg);
+  if (datum_type == 'o') return &(dt.obstacle_mm);
+  if (datum_type == 'b') return &(dt.bearing_deg);
+  if (datum_type == 'r') return &(dt.probability);
+  if (datum_type == 'p') return &(dt.posE_cm);
+  if (datum_type == 'q') return &(dt.posN_cm);
+  return nullptr;
+}
+
+ParseStateError ParseState::update(unsigned int max_passthru_ct) {
+  dt->clear();
+
+  uint8_t c; // The temp var for the newest byte.
+
+  uint8_t buffer[MAX_MSG_SIZE];
+  size_t buffer_idx = 0;
+
+  // 1) Discard all bytes until receiving the head of a new packet.
+  //    Do this b/c, in general, the node has just finished writing a new packet,
+  //    and during this time, any incoming packet would already have been
+  //    partially discarded.
+  // 2) For all new packets, pass through all non-captured packets.
+  // 1&2) While waiting for a new packet, detect lack of packets on the wire,
+  //      so that this method can exit and give the single thread a chance to
+  //      send a new packet.
+  // Note, it is possible for a correctly formatted packet without a recipient
+  // to circulate on the wire indefinitely.
+  unsigned int passthru_ct = 0;
+  while(true) {
+    c = input->read();
+
+    if (is_unavailable_byte(c)) {
+      // Ideally we should use a threshold to recognize a few contiguous
+      // `unavailable` bytes, but an attempt to do so resulted in either hanging
+      // or perpetual `unavailable` result; further investigation is welcome.
+      // If we use a threshold, it may be good for every node to add a jitter,
+      // so that every node waits a different amount to verify the `unavailable`
+      // condition, in order to prevent nodes from continuously sending new
+      // packets at the same frequency, only to have them all discarded.
+      return ParseStateError::unavailable;
     } else {
-      msgChecksum *= 10;
-      msgChecksum += c - '0';
-      goto start;
-    }
-  case 41: // negative checksum
-    if (c == '\n') {
-      if (checksum != msgChecksum) {
-        state = 0;
-        return ParseStateError::bad_checksum;
+      if (c == TERMINAL_CHAR && passthru_ct > max_passthru_ct) {
+        output->print(c);
+        return ParseStateError::passthru;
+      }
+
+      MsgType msg_type = parse_msg_type(c);
+
+      if (msg_type == MsgType::none) {
+        // Not the head of a new packet.
+        // Either discard or pass thru.
+        if (passthru_ct > 0) {
+          output->print(c);
+        }
+      } else if (msg_type & capture) {
+        // Received the head of a captured packet.
+        buffer[buffer_idx++] = c;
+        dt->kind = msg_type;
+        // Now go parse the rest of the packet.
+        break; 
       } else {
-        state = 0;
+        // Received the head of a non-captured packet.
+        output->print(c);
+        passthru_ct++;
+      }
+    }
+  }
+
+  auto get_next_byte = [this, &buffer, &buffer_idx](uint8_t & c) {
+    do {
+      c = this->input->read();
+    } while (is_unavailable_byte(c));
+    buffer[buffer_idx++] = c;
+  };
+
+  auto abort = [&get_next_byte, &buffer_idx, &MAX_MSG_SIZE](uint8_t & c) {
+    do {
+      get_next_byte(c);
+    } while (c != TERMINAL_CHAR && buffer_idx < MAX_MSG_SIZE);
+  };
+
+  // Unlike Serial.parseInt():
+  // - allows an initial digit to be already read
+  // - does not handle negative sign
+  // - parses an int, not a long
+  auto parseInt = [&get_next_byte, &c, &buffer_idx, &MAX_MSG_SIZE](int32_t* datum_ptr, const uint8_t & stop_char) {
+    do {
+      get_next_byte(c);
+      if (c >= '0' && c <= '9') {
+        *datum_ptr = *datum_ptr * 10 + c - '0';
+      } else {
+        return c == stop_char;
+      }
+    } while (buffer_idx < MAX_MSG_SIZE);
+    return false;
+  };
+
+  // 3) Either parse a datum or validate the checksum, as determined by the next byte. Repeat.
+  while (buffer_idx < MAX_MSG_SIZE) {
+    get_next_byte(c);
+    if (c == '{') {
+      // Then, read until '}' and parse a datum.
+
+      get_next_byte(c);
+      int32_t* datum_ptr = get_datum_ptr(*dt, c);
+      if (datum_ptr == nullptr) {
+        abort(c);
+        return ParseStateError::bad_attrib;
+      }
+
+      get_next_byte(c);
+      bool is_negative;
+      if (c == '-') {
+        *datum_ptr = 0;
+        is_negative = true;
+      } else {
+        *datum_ptr = c - '0';
+        is_negative = false;
+      }
+
+      bool parse_success = parseInt(datum_ptr, '}');
+      if (! parse_success) {
+        abort(c);
+        return ParseStateError::bad_number;
+      }
+
+      if (is_negative) {
+        *datum_ptr = *datum_ptr * -1;
+      }
+
+    } else if (c >= '0' && c <= '9') {
+      // Then, read until TERMINAL_CHAR and validate the checksum.
+
+      size_t checksum_begin_idx = buffer_idx - 1;
+
+      int32_t parsed_checksum = c - '0';
+      bool parse_success = parseInt(&parsed_checksum, TERMINAL_CHAR);
+      if (! parse_success) {
+        abort(c);
+        return ParseStateError::bad_number;
+      }
+
+      uint8_t calculated_checksum = CRC8.smbus(buffer, checksum_begin_idx);
+
+      if (calculated_checksum != static_cast<uint8_t>(parsed_checksum)) {
+        return ParseStateError::bad_checksum;
+      } else if (! dt->verify()) {
+        return ParseStateError::inval_comb;
+      } else {
         return ParseStateError::success;
       }
-    } else if (c < '0' || c > '9') {
-      return ParseStateError::bad_checksum;
     } else {
-      msgChecksum *= 10;
-      msgChecksum -= c - '0';
-      goto start;
+      // Then, the packet did not follow the format of e.g.
+      // `A{b1234}{c5678}999`
+      return ParseStateError::bad_number;
     }
-  case 50:
-    output->print((char)c);
-    if (c == '\n') {
-      state = 0;
-      return ParseStateError::passthru;
-    }
-    goto start;
   }
+
+  return ParseStateError::long_msg;
 }
 
 bool SerialData::write(HardwareSerial *dev) {
-  
   char buffer[MAX_MSG_SIZE];
-  int i = 0;
-  String string;
+  size_t i = 0;
+  bool success;
   
   switch (kind) {
-  case MsgType::drive:  buffer[i++] = 'D'; break;
-  case MsgType::sensor: buffer[i++] = 'S'; break;
-  case MsgType::goal:   buffer[i++] = 'G'; break;
-  case MsgType::seg:    buffer[i++] = 'X'; break;
-  default:              return false;
+    case MsgType::drive:  buffer[i++] = 'D'; break;
+    case MsgType::sensor: buffer[i++] = 'S'; break;
+    case MsgType::goal:   buffer[i++] = 'G'; break;
+    case MsgType::seg:    buffer[i++] = 'X'; break;
+    default:              return false;
   }
-  // At this point the value of i will be 1. No bounds check necessary
-  if (number != NaN && (kind == MsgType::goal || kind == MsgType::seg)) {
+
+  auto append_datum = [&buffer, &i](const char & datum_type, const int32_t & datum) {
+    String datum_str = String(datum);
+    size_t strLen = datum_str.length();
+
+    // 3 for '{', datum_type, '}'.
+    if (i >= MAX_MSG_SIZE - 3 - strLen) {
+      return false;
+    }
+
     buffer[i++] = '{';
-    buffer[i++] = 'n';
-    buffer[i++] = ' ';
-    string = String(number);
-    int strLen = string.length();
-    for (int j = 0; j < strLen; j++) {
-      buffer[i++] = string.charAt(j);
+    buffer[i++] = datum_type;
+    for (size_t j = 0; j < strLen; j++) {
+      buffer[i++] = datum_str.charAt(j);
     }
     buffer[i++] = '}';
+
+    return true;
+  };
+
+  // At this point the value of i will be 1. No bounds check necessary
+  if (number != NaN && (kind == MsgType::goal || kind == MsgType::seg)) {
+    success = append_datum('n', number);
+    if (! success) return false;
   }
   // At this point the max value of i is 16. No bounds check necessary
   if (speed_cmPs != NaN && kind != MsgType::goal) {
-    buffer[i++] = '{';
-    buffer[i++] = 's';
-    buffer[i++] = ' ';
-    string = String(speed_cmPs);
-    int strLen = string.length();
-    for (int j = 0; j < strLen; j++) {
-      buffer[i++] = string.charAt(j);
-    }
-    buffer[i++] = '}';
+    success = append_datum('s', speed_cmPs);
+    if (! success) return false;
   }
   // At this point the max value of i is 31. No bounds check necessary
   if (angle_mDeg != NaN && (kind == MsgType::drive || kind == MsgType::sensor)) {
-    buffer[i++] = '{';
-    buffer[i++] = 'a';
-    buffer[i++] = ' ';
-    string = String(angle_mDeg);
-    int strLen = string.length();
-    for (int j = 0; j < strLen; j++) {
-      buffer[i++] = string.charAt(j);
-    }
-    buffer[i++] = '}';
+    success = append_datum('a', angle_mDeg);
+    if (! success) return false;
   }
   // At this point the max value of i is 46. No bounds check necessary
   if (obstacle_mm != NaN && kind == MsgType::sensor) {
-    buffer[i++] = '{';
-    buffer[i++] = 'o';
-    buffer[i++] = ' ';
-    string = String(obstacle_mm);
-    int strLen = string.length();
-    for (int j = 0; j < strLen; j++) {
-      buffer[i++] = string.charAt(j);
-    }
-    buffer[i++] = '}';
+    success = append_datum('o', obstacle_mm);
+    if (! success) return false;
   }
   // At this point the max value of i is 61. No bounds check necessary
   if (bearing_deg != NaN && kind != MsgType::drive) {
-    buffer[i++] = '{';
-    buffer[i++] = 'b';
-    buffer[i++] = ' ';
-    string = String(bearing_deg);
-    int strLen = string.length();
-    for (int j = 0; j < strLen; j++) {
-      buffer[i++] = string.charAt(j);
-    }
-    buffer[i++] = '}';
+    success = append_datum('b', bearing_deg);
+    if (! success) return false;
   }
   // At this point the max value of i is 91. A bounds check is necessary
+  // if (i >= MAX_MSG_SIZE) return false;
   if (probability != NaN && kind == MsgType::goal) {
-    if (i >= MAX_MSG_SIZE - 6)
-      return false;
-    buffer[i++] = '{';
-    buffer[i++] = 'r';
-    buffer[i++] = ' ';
-    string = String(probability);
-    int strLen = string.length();
-    if (i >= MAX_MSG_SIZE - strLen - 2)
-      return false;
-    for (int j = 0; j < strLen; j++)
-      buffer[i++] = string.charAt(j);
-    buffer[i++] = '}';
+    success = append_datum('r', probability);
+    if (! success) return false;
   }
   // At this point the max value of i is 76. A bounds check is necessary
+  // if (i >= MAX_MSG_SIZE) return false;
   if (posE_cm != NaN && posN_cm != NaN && kind != MsgType::drive) {
-    if (i >= MAX_MSG_SIZE - 8)
-      return false;
-    buffer[i++] = '{';
-    buffer[i++] = 'p';
-    buffer[i++] = ' ';
-    string = String(posE_cm);
-    int strLen = string.length();
-    if (i >= MAX_MSG_SIZE - strLen - 4)
-      return false;
-    for (int j = 0; j < strLen; j++)
-      buffer[i++] = string.charAt(j);
-    buffer[i++] = ',';
-    string = String(posN_cm);
-    strLen = string.length();
-    if (i >= MAX_MSG_SIZE - strLen - 2)
-      return false;
-    for (int j = 0; j < strLen; j++)
-      buffer[i++] = string.charAt(j);
-    buffer[i++] = '}';
+    success = append_datum('p', posE_cm);
+    if (! success) return false;
+    success = append_datum('q', posN_cm);
+    if (! success) return false;
   }
-  // At this point the max value of i is 106. A bounds check is necessary
+
+  // At this point the max value of i is 108. A bounds check is necessary
+  // if (i >= MAX_MSG_SIZE) return false;
+
   FastCRC8 CRC8;
   int checksum = CRC8.smbus((const uint8_t*)buffer, i);
   String chksumStr = String(checksum);
   int chksumLen = chksumStr.length();
-  if (i == MAX_MSG_SIZE - chksumLen - 1)
+  if (i == MAX_MSG_SIZE - chksumLen - 1) // 1 for TERMINAL_CHAR
     return false;
   for (int j = 0; j < chksumLen; j++)
     buffer[i++] = chksumStr.charAt(j);
-  buffer[i++] = '\n';
-  
+
+  buffer[i++] = TERMINAL_CHAR;
+
   // Write buffer to device
   for (int j = 0; j < i; j++) {
     dev->print(buffer[j]);
@@ -334,7 +293,6 @@ void SerialData::clear(void) {
   probability = NaN;
 }
 
-/*
 bool SerialData::verify(void) {
   return true;
   switch (kind) {
@@ -368,6 +326,5 @@ bool SerialData::verify(void) {
   }
   return true;
 }
-*/
 
 } // namespace elcano

--- a/libraries/ElcanoSerial/ElcanoSerial.h
+++ b/libraries/ElcanoSerial/ElcanoSerial.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <HardwareSerial.h>
-#include <FastCRC.h>
 
 // Elcano_Serial.h
 // By Dylan Katz
@@ -18,6 +17,10 @@ const int32_t baudrate = 74800;
 
 //! The maximum message size
 const int32_t MAX_MSG_SIZE = 64;
+
+//! The min continuous occurrence of the unavailable byte (255) that is
+//  interprted as the absence of any message on the wire.
+const int32_t MIN_UNAVAILABLE_CT = 0;
 
 //! The different possible types of SerialData packets
 enum class MsgType : int8_t {
@@ -51,7 +54,7 @@ struct SerialData {
 
   void clear(void);  //!< Set the values to the defaults
   bool write(HardwareSerial * /**< Connection to write to */); //!< Write to a serial connection
-  //bool verify(void); //!< Check that the types match the values
+  bool verify(void); //!< Check that the types match the values
 };
 
 //! The different possible results of the ParseState::update method
@@ -59,13 +62,11 @@ enum class ParseStateError : int8_t {
   success      = 0, //!< Complete package
   inval_comb   = 1, //!< Complete package, failed validation
   unavailable  = 2, //!< Couldn't read a complete packet from the device at this time
-  bad_type     = 3, //!< Syntax error: types should be [DSGX]
-  bad_lcurly   = 4, //!< Syntax error: expected '{' or '\n' but got neither
   bad_attrib   = 5, //!< Syntax error: attributes should be [nsaobrp] and only used once
   bad_number   = 6, //!< Syntax error: number had a bad symbol
   passthru     = 7, //!< An uncaptured message has been passed through
   bad_checksum = 8, //!< Error in checksum
-  long_msg     = 9  //!< Message is too long
+  long_msg     = 9 //!< Message is too long
 };
 
 //! Contains internal state for the SerialData parser.
@@ -74,11 +75,9 @@ struct ParseState {
   HardwareSerial *input;  //!< Connection to read from
   HardwareSerial *output; //!< Connection to write to
   MsgType capture;        //!< MsgType(s) to capture
-  char mostRecent;
-  ParseStateError update(void); //!< Update the state of the parser based on a single character
-private:
-  uint8_t state = 0;   //!< Internal state variable
-  FastCRC8 CRC8;
+
+  //!< Update the state of the parser based on a single character
+  ParseStateError update(unsigned int max_passthru_ct = 50);
 };
 
 } // namespace elcano

--- a/libraries/ElcanoSerial/TestSuite/C1/C1.ino
+++ b/libraries/ElcanoSerial/TestSuite/C1/C1.ino
@@ -33,28 +33,7 @@ void loop() {
     start = millis();
   } else if (err != elcano::ParseStateError::passthru && err != elcano::ParseStateError::unavailable) {
     dt1.write(&Serial);
-    Serial.print("Error (");
-    Serial.print(static_cast<int8_t>(err));
-    Serial.print("): recieved ");
-    switch (err) {
-    case elcano::ParseStateError::inval_comb:
-      Serial.println("an invalid combination of attributes for a type!");
-      break;
-    case elcano::ParseStateError::bad_type:
-      Serial.println("a bad type!");
-      break;
-    case elcano::ParseStateError::bad_lcurly:
-      Serial.println("a bad left `{'!");
-      break;
-    case elcano::ParseStateError::bad_attrib:
-      Serial.println("a bad attribute!");
-      break;
-    case elcano::ParseStateError::bad_number:
-      Serial.println("a bad number!");
-      break;
-    default:
-      Serial.println("an unknown error!");
-    }
+    Serial.println(static_cast<int8_t>(err));
   }
 
   err = ps2.update();
@@ -62,27 +41,6 @@ void loop() {
     start = millis();
   } else if (err != elcano::ParseStateError::unavailable) {
     dt1.write(&Serial);
-    Serial.print("Error (");
-    Serial.print(static_cast<int8_t>(err));
-    Serial.print("): recieved ");
-    switch (err) {
-    case elcano::ParseStateError::inval_comb:
-      Serial.println("an invalid combination of attributes for a type!");
-      break;
-    case elcano::ParseStateError::bad_type:
-      Serial.println("a bad type!");
-      break;
-    case elcano::ParseStateError::bad_lcurly:
-      Serial.println("a bad left `{'!");
-      break;
-    case elcano::ParseStateError::bad_attrib:
-      Serial.println("a bad attribute!");
-      break;
-    case elcano::ParseStateError::bad_number:
-      Serial.println("a bad number!");
-      break;
-    default:
-      Serial.println("an unknown error!");
-    }
+    Serial.println(static_cast<int8_t>(err));
   }
 }

--- a/libraries/ElcanoSerial/TestSuite/C2/C2.ino
+++ b/libraries/ElcanoSerial/TestSuite/C2/C2.ino
@@ -24,28 +24,10 @@ void setup() {
 
 void loop() {
   elcano::ParseStateError err = ps1.update();
-  if (err == elcano::ParseStateError::success) {
+  Serial.println(static_cast<int8_t>(err));
+
+  if (err == elcano::ParseStateError::passthru ||
+      err == elcano::ParseStateError::unavailable) {
     dt2.write(&Serial2);
-  } else if (err != elcano::ParseStateError::passthru) {
-    Serial.print("Error: recieved ");
-    switch (err) {
-    case elcano::ParseStateError::inval_comb:
-      Serial.println("an invalid combination of attributes for a type!");
-      break;
-    case elcano::ParseStateError::bad_type:
-      Serial.println("a bad type!");
-      break;
-    case elcano::ParseStateError::bad_lcurly:
-      Serial.println("a bad left `{'!");
-      break;
-    case elcano::ParseStateError::bad_attrib:
-      Serial.println("a bad attribute!");
-      break;
-    case elcano::ParseStateError::bad_number:
-      Serial.println("a bad number!");
-      break;
-    default:
-      Serial.println("an unknown error!");
-    }
   }
 }

--- a/libraries/ElcanoSerial/TestSuite/C3/C3.ino
+++ b/libraries/ElcanoSerial/TestSuite/C3/C3.ino
@@ -16,7 +16,7 @@ void setup() {
   dt2.clear();
   dt2.kind = elcano::MsgType::drive;
   dt2.speed_cmPs = 123456;
-  dt2.angle_deg = 32;
+  dt2.angle_mDeg = 32;
 }
 
 void loop() {

--- a/libraries/ElcanoSerial/TestSuite/C3/C3.ino
+++ b/libraries/ElcanoSerial/TestSuite/C3/C3.ino
@@ -21,28 +21,10 @@ void setup() {
 
 void loop() {
   elcano::ParseStateError err = ps1.update();
-  if (err == elcano::ParseStateError::success) {
+  Serial.println(static_cast<int8_t>(err));
+
+  if (err == elcano::ParseStateError::passthru ||
+      err == elcano::ParseStateError::unavailable) {
     dt2.write(&Serial2);
-  } else if (err != elcano::ParseStateError::passthru) {
-    Serial.print("Error: recieved ");
-    switch (err) {
-    case elcano::ParseStateError::inval_comb:
-      Serial.println("an invalid combination of attributes for a type!");
-      break;
-    case elcano::ParseStateError::bad_type:
-      Serial.println("a bad type!");
-      break;
-    case elcano::ParseStateError::bad_lcurly:
-      Serial.println("a bad left `{'!");
-      break;
-    case elcano::ParseStateError::bad_attrib:
-      Serial.println("a bad attribute!");
-      break;
-    case elcano::ParseStateError::bad_number:
-      Serial.println("a bad number!");
-      break;
-    default:
-      Serial.println("an unknown error!");
-    }
   }
 }

--- a/libraries/ElcanoSerial/UnidirectionalTest/C1/C1.ino
+++ b/libraries/ElcanoSerial/UnidirectionalTest/C1/C1.ino
@@ -1,0 +1,51 @@
+#include <ElcanoSerial.h>
+
+elcano::SerialData dt;
+
+//void setupData() {
+//  dt.kind = elcano::MsgType::drive;
+//  dt.speed_cmPs = 11;
+//  dt.angle_mDeg = -21;
+//}
+//void loopData() {
+//  dt.speed_cmPs += 1;
+//  dt.angle_mDeg -= 1;
+//}
+
+void setupData() {
+  dt.kind = elcano::MsgType::goal;
+  dt.posE_cm = 31;
+  dt.posN_cm = -41;
+}
+void loopData() {
+  dt.posE_cm += 1;
+  dt.posN_cm -= 1;
+}
+
+//void setupData() {
+//  dt.kind = elcano::MsgType::sensor;
+//  dt.angle_mDeg = 51;
+//  dt.obstacle_mm = -61;
+//}
+//void loopData() {
+//  dt.angle_mDeg += 1;
+//  dt.obstacle_mm -= 1;
+//}
+
+void setup() {
+  Serial.begin(9600);
+  Serial2.begin(elcano::baudrate);
+
+  dt.clear();
+  setupData();
+}
+
+void loop() {
+  loopData();  
+  dt.write(&Serial2);
+  dt.write(&Serial);
+
+  // Adjust this to a realistic period.
+  // Use a large number like 1000 if the recipient (C2) is printing a lot of characters.
+  delay(10);
+}

--- a/libraries/ElcanoSerial/UnidirectionalTest/C2/C2.ino
+++ b/libraries/ElcanoSerial/UnidirectionalTest/C2/C2.ino
@@ -1,0 +1,34 @@
+#include <ElcanoSerial.h>
+
+elcano::ParseState ps;
+elcano::SerialData dt;
+
+void setup() {
+  Serial.begin(9600);
+  Serial1.begin(elcano::baudrate);
+  Serial2.begin(elcano::baudrate);
+
+  ps.dt = &dt;
+  ps.input = &Serial1;
+  ps.output = &Serial2;
+  ps.capture = (elcano::MsgType::drive | elcano::MsgType::goal);
+}
+
+void loop() {
+  elcano::ParseStateError err = ps.update();
+
+  Serial.println(static_cast<int8_t>(err));
+
+//  if (err != elcano::ParseStateError::unavailable) {
+//    Serial.println("err " + String(static_cast<int8_t>(err)));
+//    Serial.println("  kind " + String(static_cast<int8_t>(dt.kind)));
+//    Serial.println("  number " + String(dt.number));
+//    Serial.println("  speed_cmPs " + String(dt.speed_cmPs));
+//    Serial.println("  angle_mDeg " + String(dt.angle_mDeg));
+//    Serial.println("  obstacle_mm " + String(dt.obstacle_mm));
+//    Serial.println("  probability " + String(dt.probability));
+//    Serial.println("  bearing_deg " + String(dt.bearing_deg));
+//    Serial.println("  posE_cm " + String(dt.posE_cm));
+//    Serial.println("  posN_cm " + String(dt.posN_cm));
+//  }
+}


### PR DESCRIPTION
This is an update to the `ParseState::update` method. The objective is to fix the message passing. CRC was suspected to be a culprit.

This change was tested with 2 Mega nodes. A loop with 3 nodes has not been tested yet. A tester for unidirectional message sending was also added. 

### The changes that likely fixed the issues:

- Previously, the `unavailable` byte was -1; now we're comparing with 255. This is appropriate since the data type is 8 bits.
- It is possible, though not certain, that the code handling negative CRC values was causing an edge case. In the `case '-'` line, `msgChecksum` is never assigned, so the checksum comparison never evaluates true. However, the CRC8 value should never be negative, so it is possible that this is a red herring.
- Previously, there were two code paths where `ParseState::update` returned without resetting `state` instance variable. This must have resulted in lost packets.

### The nature of the rewrite:

The previous code in the style of finite state machine was hard to follow. Since all execution within `ParseState::update` is synchronous, this style is not necessary. The new code uses a series of loops. Macros were replaced with functions and the use of pointers.

### Functional changes:

- `ParseState::update` no longer errors out for duplicate datum fields, as in the duplicate `x` in a hypothetical packet `X{x1234}{x5678}99\n`. We can avoid this by checking the implementation of `SerialData::write` statically/manually. This alleviates code complexity and runtime cost.
- Two types of `ParseStateError` were removed, in the course of the refactoring.
- Previously, the packet had a special format for `posE_cm` and `posN_cm`, where the two values were serialized inside the same brackets separated by commas, as in `{p1234,5678}`. This is now separated into two brackets, as in `{p1234}{q5678}`. Code simplification is significant, and the cost of two additional bytes should be negligible.
- Calling of `SerialData::verify` was added back in. If this was previously commented out due to performance, we can take it out again.
- `SerialData::write` checks overflow over `MAX_MSG_SIZE` more frequently. Not sure if the selective checking was done for a performance reason, but I believe the effect is minimal.
- Improvement: the previous code did not explicitly address the fact that, in general, at the time `ParseState::update` executes, the initial bytes are the middle bytes of a packet, and hence should be discarded. I believe the discarding happened anyway, but it was implicit. The new code makes it explicit, and makes further optimizations possible.

### What did not change:

The new code parses as much as possible for every byte, in order to prevent unbalanced load of computation at specific tokens (e.g. `}` and `\n`). However, the code would be much more readable if we can parse at the end. To allow for longer latency, lower baud rate may be sufficient. Now that we have only 3 nodes (LowLevel, HighLevel, remote control), maybe the reduced amount of packets makes this possible.

P.S. you can use `?w=1` flag to ignore whitespaces: https://github.com/elcano/elcano/pull/171/files?w=1