### PR TITLE
Fix bug in C2_LowLevel loop timing code.

### DIFF
--- a/Elcano_C2_LowLevel/Elcano_C2_LowLevel.ino
+++ b/Elcano_C2_LowLevel/Elcano_C2_LowLevel.ino
@@ -414,7 +414,7 @@ void loop()
   // minimal time between now, when we capture the actual loop end time,
   // and when we pause til the desired loop end time.
   endTime = millis();
-  delayTime = 0L;
+  delayTime = 0UL;
 
   // Did the millis() counter or nextTime overflow and roll over during
   // this loop pass? Did the loop's processing time overrun the desired
@@ -457,13 +457,13 @@ void loop()
       // In this case, we have no delay, but instead extend the allowed time for
       // this loop pass to the actual time it took.
       nextTime = endTime;
-      delayTime = 0L;
+      delayTime = 0UL;
     }
   }
   
   // Did we spend long enough in the loop that we should immediately start
   // the next pass?
-  if (delayTime > 0L) {
+  if (delayTime > 0UL) {
     // No, pause til the next loop start time.
     delay(delayTime);
   }


### PR DESCRIPTION
Joe and others observed that the C2_LowLevel would go through one loop pass, and then hang. If students would like to try debugging, look at the prior version of C2_LowLevel, and figure out what happened. Spoiler alert -- don't read the rest of this comment.

Pause for folks to go bug hunting...

The loop timing code is buggy. It uses an unsigned variable for a signed quantity that is almost certainly negative. Observed symptom was that the loop went through one pass then hung. That is consistent with a very very very large delay time, when the negative number is interpreted as a very very very large positive number. Two takeaways: First, do not use unsigned unless you are entirely certain you have positive quantities. Presence of a subtraction should be a warning flag. Walk through code paths with all cases. Second, test your work before pushing it into the main repository. Due to time constraints, I am putting back the last working loop code, which is the rollover protection code. We can have a debate about whether this should be kept at some later date. Right now, we need to have the loop working. Also, it appears the include of ElcanoSerial.h was removed at some point. That is necessary -- the file won't even compile without it -- so I've put it back.